### PR TITLE
[#249] blueprints: add an Ammo type bucket to the Type filter

### DIFF
--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -142,7 +142,7 @@ You can also check manually anytime with **Check for Updates** on the Config tab
 Track which crafting blueprints you already own, and see it reflected in-game: owned items get a blue `[Owned]` tag in mission POTENTIAL BLUEPRINTS lists, so a contract listing tells you at a glance what you still need to hunt down.
 
 - **Two lists, one shuttle.** Available blueprints on the left, your owned set on the right. Select items and move them with the arrow buttons. The owned set persists across restarts.
-- **Find things fast.** A search box narrows both lists, and the **Mission / Type / Class / Size / Grade** filters cut the available list down by where a blueprint drops and what kind of item it is (Armor, FPS Weapon, Ship Item, and so on).
+- **Find things fast.** A search box narrows both lists, and the **Mission / Type / Class / Size / Grade** filters cut the available list down by where a blueprint drops and what kind of item it is (Armor, Ammo, FPS Weapon, Ship Item, and so on).
 - **Scan Logs for Owned Blueprints** fills the owned set automatically: it reads your Star Citizen log files for the blueprints you've received in-game and marks them owned. Only blueprints received since your last scan are imported, so re-running it any time is cheap. The scan needs your Star Citizen install path set on the Config tab.
 - **Apply Owned Tags** re-weaves the `[Owned]` tags into your loaded strings after you change the owned set. Like the other action buttons, it turns **red** when your owned list has changes the table hasn't picked up yet and **green** once everything matches.
 - The strings table's **Owned** column still shows a star and sorts owned-first, but it's read-only now; ownership is managed from this tab.

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -112,7 +112,18 @@ _ITEM_NAME_PREFIX = "item_Name"
 _TYPE_FPS_WEAPON = "FPS Weapon"
 _TYPE_SHIP_WEAPON = "Ship Weapon"
 _TYPE_ARMOR = "Armor"
+_TYPE_AMMO = "Ammo"
 _TYPE_OTHER = "Other"
+
+# Ammo/magazine loc keys always end in "_mag" (optionally "_empty"/"_filled",
+# e.g. the salvage canister pair item_Name..._salvage_mag_empty /
+# ..._salvage_mag_filled) (#249). Anchored to the end of the key rather than a
+# bare "_mag" substring match: several weapon keys carry "_rifle_"/"_pistol_"/
+# etc tokens that would otherwise win the FPS Weapon bucket first (e.g.
+# item_Namebehr_rifle_ballistic_01_mag -> "P4-AR Magazine"), and an end anchor
+# also rules out unrelated items that merely contain "mag" mid-key (e.g.
+# item_NameFlair_Poster_SM_Mag_Cover, a physical magazine poster, not ammo).
+_AMMO_KEY_SUFFIXES = ("_mag", "_mag_empty", "_mag_filled")
 
 # Friendly labels for the component type codes that appear right after
 # ``item_Name`` / ``item_Name_`` in a component loc key. Codes not in this map
@@ -248,6 +259,8 @@ def blueprint_type_from_key(key: str):
     if t:
         return t
     kl = key.lower()
+    if kl.endswith(_AMMO_KEY_SUFFIXES):
+        return _TYPE_AMMO
     if any(w in kl for w in _FPS_WEAPON_WORDS):
         return _TYPE_FPS_WEAPON
     if any(w in kl for w in _ARMOR_GEAR_WORDS) or any(w in kl for w in _ARMOR_EXTRA_WORDS):

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -112,7 +112,18 @@ _ITEM_NAME_PREFIX = "item_Name"
 _TYPE_FPS_WEAPON = "FPS Weapon"
 _TYPE_SHIP_WEAPON = "Ship Weapon"
 _TYPE_ARMOR = "Armor"
+_TYPE_AMMO = "Ammo"
 _TYPE_OTHER = "Other"
+
+# Ammo/magazine loc keys always end in "_mag" (optionally "_empty"/"_filled",
+# e.g. the salvage canister pair item_Name..._salvage_mag_empty /
+# ..._salvage_mag_filled) (#249). Anchored to the end of the key rather than a
+# bare "_mag" substring match: several weapon keys carry "_rifle_"/"_pistol_"/
+# etc tokens that would otherwise win the FPS Weapon bucket first (e.g.
+# item_Namebehr_rifle_ballistic_01_mag -> "P4-AR Magazine"), and an end anchor
+# also rules out unrelated items that merely contain "mag" mid-key (e.g.
+# item_NameFlair_Poster_SM_Mag_Cover, a physical magazine poster, not ammo).
+_AMMO_KEY_SUFFIXES = ("_mag", "_mag_empty", "_mag_filled")
 
 # Friendly labels for the component type codes that appear right after
 # ``item_Name`` / ``item_Name_`` in a component loc key. Codes not in this map
@@ -351,6 +362,8 @@ def blueprint_type_from_key(key: str):
     if t:
         return t
     kl = key.lower()
+    if kl.endswith(_AMMO_KEY_SUFFIXES):
+        return _TYPE_AMMO
     if any(w in kl for w in _FPS_WEAPON_WORDS):
         return _TYPE_FPS_WEAPON
     if any(w in kl for w in _ARMOR_GEAR_WORDS) or any(w in kl for w in _ARMOR_EXTRA_WORDS):

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -154,6 +154,25 @@ def test_blueprint_type_armor_core_pieces():
     assert blueprint_type_from_key("item_Name_gys_highscore_01_01_01") is None
 
 
+def test_blueprint_type_ammo_and_magazines():
+    """Ammo/magazine blueprints (#249) get their own "Ammo" bucket instead of
+    landing in "Other" (or, worse, "FPS Weapon" — many mag keys carry a
+    "_rifle_"/"_pistol_"/etc token that would otherwise win first)."""
+    assert blueprint_type_from_key("item_Namebehr_rifle_ballistic_01_mag") == "Ammo"
+    assert blueprint_type_from_key("item_NameGMNI_smg_ballistic_01_mag") == "Ammo"
+    assert blueprint_type_from_key("item_Nameklwe_lmg_energy_01_mag") == "Ammo"
+    assert blueprint_type_from_key("item_Nameutfl_crossbow_ballistic_01_mag") == "Ammo"
+    # Salvage/healing canister pairs — "_mag" with an _empty/_filled state suffix.
+    assert blueprint_type_from_key("item_Namegrin_multitool_01_salvage_mag_empty") == "Ammo"
+    assert blueprint_type_from_key("item_Namegrin_multitool_01_salvage_mag_filled") == "Ammo"
+    assert blueprint_type_from_key("item_Namegrin_multitool_01_healing_mag") == "Ammo"
+    # Keys that merely contain "mag" mid-string (not a trailing _mag token) are
+    # NOT ammo — e.g. a physical magazine/poster item.
+    assert blueprint_type_from_key("item_NameFlair_Poster_SM_Mag_Cover") is None
+    # A recognized ship-component code still wins first (unaffected by this bucket).
+    assert blueprint_type_from_key("item_NameSHLD_ACOM_S01") == "Shield"
+
+
 def test_blueprint_type_gys_jacket_and_pants():
     """Carnifex set torso/leg pieces reported showing up in "Other" — the
     "gys" manufacturer keys these as jacket/pants, not core/legs/armor."""

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -210,6 +210,17 @@ def test_blueprint_type_ammo_and_magazines():
     assert blueprint_type_from_key("item_NameSHLD_ACOM_S01") == "Shield"
 
 
+def test_blueprint_type_ammo_suffix_checked_before_mining_head_carveout():
+    """Locks the classifier's ordering (#249 review): component-code -> Ammo
+    suffix -> FPS weapon/armor -> mining-head carve-out (#290) -> ship-weapon
+    heuristic (#212). Neither #249 nor #290 should ever shadow the other --
+    an ammo key ending in one of _AMMO_KEY_SUFFIXES must classify as Ammo
+    even if it also happens to contain "mining_head", and a real mining-head
+    key with no ammo suffix must still land in Other, not Ammo."""
+    assert blueprint_type_from_key("item_NameMining_Head_S00_Test_mag") == "Ammo"
+    assert blueprint_type_from_key("item_NameMining_Head_S00_Arbor_SCItem") is None
+
+
 def test_blueprint_type_gys_jacket_and_pants():
     """Carnifex set torso/leg pieces reported showing up in "Other" — the
     "gys" manufacturer keys these as jacket/pants, not core/legs/armor."""

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -191,6 +191,25 @@ def test_blueprint_type_armor_core_pieces():
     assert blueprint_type_from_key("item_Name_gys_highscore_01_01_01") is None
 
 
+def test_blueprint_type_ammo_and_magazines():
+    """Ammo/magazine blueprints (#249) get their own "Ammo" bucket instead of
+    landing in "Other" (or, worse, "FPS Weapon" — many mag keys carry a
+    "_rifle_"/"_pistol_"/etc token that would otherwise win first)."""
+    assert blueprint_type_from_key("item_Namebehr_rifle_ballistic_01_mag") == "Ammo"
+    assert blueprint_type_from_key("item_NameGMNI_smg_ballistic_01_mag") == "Ammo"
+    assert blueprint_type_from_key("item_Nameklwe_lmg_energy_01_mag") == "Ammo"
+    assert blueprint_type_from_key("item_Nameutfl_crossbow_ballistic_01_mag") == "Ammo"
+    # Salvage/healing canister pairs — "_mag" with an _empty/_filled state suffix.
+    assert blueprint_type_from_key("item_Namegrin_multitool_01_salvage_mag_empty") == "Ammo"
+    assert blueprint_type_from_key("item_Namegrin_multitool_01_salvage_mag_filled") == "Ammo"
+    assert blueprint_type_from_key("item_Namegrin_multitool_01_healing_mag") == "Ammo"
+    # Keys that merely contain "mag" mid-string (not a trailing _mag token) are
+    # NOT ammo — e.g. a physical magazine/poster item.
+    assert blueprint_type_from_key("item_NameFlair_Poster_SM_Mag_Cover") is None
+    # A recognized ship-component code still wins first (unaffected by this bucket).
+    assert blueprint_type_from_key("item_NameSHLD_ACOM_S01") == "Shield"
+
+
 def test_blueprint_type_gys_jacket_and_pants():
     """Carnifex set torso/leg pieces reported showing up in "Other" — the
     "gys" manufacturer keys these as jacket/pants, not core/legs/armor."""


### PR DESCRIPTION
## Summary
- Ammo/magazine blueprints (P4-AR Magazine, Demeco LMG Battery, salvage/healing canisters, ...) had no dedicated Type bucket in the Blueprint Tracker.
- Their loc keys often contain a weapon-token substring (`_rifle_`, `_pistol_`, ...), so `blueprint_type_from_key` was actually routing most of them into "FPS Weapon" rather than "Other" as reported; the rest fell to "Other" either way.
- Added a check for the `_mag` / `_mag_empty` / `_mag_filled` key suffix (the pattern CIG uses across every ballistic/energy magazine and salvage/healing canister), ahead of the FPS-weapon check, bucketing those into a new "Ammo" type.

Closes #249.

## Testing Checklist
- [x] PR is scoped to one concern (single bug fix / classifier addition)
- [x] `pytest tests/` passes locally (1188 passed, 16 skipped)
- [ ] App launches: `python src/main.py`
- [ ] Affected user-facing flow exercised manually (Blueprint Tracker Type filter)
- [x] User-facing strings, `docs/HELP.md`, `docs/ABOUT.md`, and `src/gui/coach_mark.py` reviewed for drift (none needed — Type filter values are populated dynamically from data, no new UI strings)
- [x] New non-exempt code has matching test coverage in `tests/test_blueprint_meta.py`
- [x] Target branch is the active `release/2.3.0`, not `main`
- [x] No direct `QSettings` calls, no hard-coded column indices, no `QProgressBar.setValue()` from workers
- [ ] If new enhancement category: `CATEGORY_SUBTREES` and `DATAFORGE_KEEP_SUBPATHS` both updated (n/a — this is a Blueprint Tracker display-only classification, not an enhancement category)
- [x] `VERSION.TXT` matches the active release branch (bumped to 2.3.0 in this branch's parent commit)

## Testing performed
Ran the full test suite (`pytest tests/`) — 1188 passed, 16 skipped. Added 6 new unit test assertions in `test_blueprint_meta.py` covering ballistic/energy magazines, salvage/healing canister empty/filled states, a ship-component precedence check, and a false-positive guard (a "Magazine" poster item whose key contains `_Mag_` mid-string but doesn't end in it). Have not yet manually exercised the Blueprint Tracker Type filter dropdown in the running app against live game data.

## Post-merge QA
Things to validate after this lands on the integration branch:
- [ ] App launches from a clean checkout of the integration branch (no leftover state)
- [ ] Blueprint Tracker Type filter shows an "Ammo" option and correctly buckets magazine/battery/canister blueprint items instead of "FPS Weapon" or "Other"
- [ ] Tutorial coach-marks still land on the correct widgets (unaffected by this change, but worth a quick check)

---
🤖 PR description generated with [Claude Code](https://claude.com/claude-code) and reviewed by @Stealrull