### PR TITLE
Show a clear message when Data.p4k is locked by the RSI Launcher

### DIFF
--- a/languages/english/ui.json
+++ b/languages/english/ui.json
@@ -2337,7 +2337,7 @@
       "at": ""
     },
     "p4k_locked": {
-      "ht": "Star Citizen appears to be updating right now — its game files (Data.p4k) are locked by another program, usually the RSI Launcher downloading or verifying an update.\n\nWait until all updates and verification finish in the RSI Launcher, then try again.",
+      "ht": "Star Citizen appears to be updating right now. Its game files (Data.p4k) are locked by another program, usually the RSI Launcher downloading or verifying an update.\n\nWait until all updates and verification finish in the RSI Launcher, then try again.",
       "at": ""
     }
   },

--- a/languages/english/ui.json
+++ b/languages/english/ui.json
@@ -2335,6 +2335,10 @@
     "extraction_error_title": {
       "ht": "Extraction Error",
       "at": ""
+    },
+    "p4k_locked": {
+      "ht": "Star Citizen appears to be updating right now — its game files (Data.p4k) are locked by another program, usually the RSI Launcher downloading or verifying an update.\n\nWait until all updates and verification finish in the RSI Launcher, then try again.",
+      "at": ""
     }
   },
   "apply": {

--- a/languages/french/ui.json
+++ b/languages/french/ui.json
@@ -2335,6 +2335,10 @@
     "extraction_error_title": {
       "ht": "",
       "at": "Erreur d'extraction"
+    },
+    "p4k_locked": {
+      "ht": "",
+      "at": ""
     }
   },
   "apply": {

--- a/languages/portuguese_br/ui.json
+++ b/languages/portuguese_br/ui.json
@@ -2335,6 +2335,10 @@
     "extraction_error_title": {
       "ht": "",
       "at": "Erro de extração"
+    },
+    "p4k_locked": {
+      "ht": "",
+      "at": ""
     }
   },
   "apply": {

--- a/languages/spanish/ui.json
+++ b/languages/spanish/ui.json
@@ -2335,6 +2335,10 @@
     "extraction_error_title": {
       "ht": "",
       "at": "Error de extracción"
+    },
+    "p4k_locked": {
+      "ht": "",
+      "at": ""
     }
   },
   "apply": {

--- a/src/gui/workers.py
+++ b/src/gui/workers.py
@@ -454,7 +454,7 @@ class P4kExtractWorker(QThread):
         self._exe = unp4k_exe
 
     def run(self):
-        from src.utils.pak_extractor import extract_global_ini
+        from src.utils.pak_extractor import P4kLockedError, extract_global_ini
         try:
             extract_global_ini(
                 self._p4k, self._out, self._exe,
@@ -462,6 +462,15 @@ class P4kExtractWorker(QThread):
                 progress_pct_callback=lambda c, t, m: self.progress_pct.emit(c, t, m),
             )
             self.finished.emit(True)
+        except P4kLockedError as e:
+            # Anticipated, already logged at WARNING by _raise_unp4k_failure
+            # with full diagnostic detail — logger.exception() here would
+            # independently trigger MainWindow's global ErrorDialogHandler
+            # (any ERROR-level record, app-wide) and duplicate the friendly
+            # dialog the `error` signal below shows.
+            logger.warning(f"P4K extraction: Data.p4k locked, likely updating: {e}")
+            self.error.emit(str(e))
+            self.finished.emit(False)
         except Exception as e:
             logger.exception(f"P4K extraction failed: {e}")
             self.error.emit(str(e))
@@ -484,7 +493,7 @@ class DataForgeExtractWorker(QThread):
         self._cache_dir = cache_dir
 
     def run(self):
-        from src.utils.pak_extractor import extract_dataforge
+        from src.utils.pak_extractor import P4kLockedError, extract_dataforge
         from src.utils.dataforge_patcher import apply_patches
         try:
             extract_dataforge(
@@ -516,6 +525,14 @@ class DataForgeExtractWorker(QThread):
                 for err in report.errors:
                     logger.warning(f"  patch error: {err}")
             self.finished.emit(True)
+        except P4kLockedError as e:
+            # See the matching comment in P4kExtractWorker.run(): already
+            # logged at WARNING by _raise_unp4k_failure; logger.exception()
+            # here would independently trigger the global ErrorDialogHandler
+            # and duplicate the friendly dialog the `error` signal shows.
+            logger.warning(f"DataForge extraction: Data.p4k locked, likely updating: {e}")
+            self.error.emit(str(e))
+            self.finished.emit(False)
         except Exception as e:
             logger.exception(f"DataForge extraction failed: {e}")
             self.error.emit(str(e))

--- a/src/utils/pak_extractor.py
+++ b/src/utils/pak_extractor.py
@@ -47,11 +47,26 @@ def _raise_unp4k_failure(returncode: int, output: str) -> None:
     by another process (the common case — the user launched an extract while
     the RSI Launcher was patching). Always logs the raw output first so the Log
     tab keeps the underlying technical detail even when the friendly message is
-    shown. Never returns — always raises."""
+    shown. Never returns — always raises.
+
+    Logged at WARNING, not ERROR, for the locked-file case specifically:
+    MainWindow's global ErrorDialogHandler pops its own generic "Smart
+    Citizen — Error / Show Log / Dismiss" dialog for every ERROR-level log
+    record, anywhere in the app (error_dialog.py). That's meant for genuinely
+    unexpected failures; a locked Data.p4k is an anticipated, well-understood
+    condition with its own dedicated friendly dialog (the one this raises
+    into), so logging it at ERROR duplicated that dialog with a second,
+    confusing raw-stack-trace popup on top of it. Any OTHER unp4k failure
+    still logs at ERROR — those are genuinely unexpected and should still
+    surface through the generic handler."""
     output = output or ""
-    logger.error(f"unp4k.exe exited with code {returncode}; output:\n{output[:2000]}")
     if _P4K_LOCKED_SIGNATURE in output.lower():
+        logger.warning(
+            f"unp4k.exe exited with code {returncode} — Data.p4k is locked "
+            f"(game likely updating); output:\n{output[:2000]}"
+        )
         raise RuntimeError(tr("extract.p4k_locked"))
+    logger.error(f"unp4k.exe exited with code {returncode}; output:\n{output[:2000]}")
     raise RuntimeError(f"unp4k.exe exited with code {returncode}.\n\n{output}")
 
 

--- a/src/utils/pak_extractor.py
+++ b/src/utils/pak_extractor.py
@@ -39,8 +39,24 @@ _RMTREE_CB_KWARG = "onexc" if sys.version_info >= (3, 12) else "onerror"
 _P4K_LOCKED_SIGNATURE = "being used by another process"
 
 
+class P4kLockedError(RuntimeError):
+    """Data.p4k is locked by another process (RSI Launcher updating/verifying).
+
+    A RuntimeError subclass, not a plain RuntimeError, so P4kExtractWorker /
+    DataForgeExtractWorker (workers.py) can tell this anticipated, already-
+    friendly-messaged condition apart from a genuinely unexpected extraction
+    failure — via isinstance(), not by re-sniffing the message text a second
+    time. Both workers' blanket ``except Exception`` handlers otherwise call
+    logger.exception() unconditionally, which independently satisfies
+    MainWindow's global ErrorDialogHandler (error_dialog.py, triggers on any
+    ERROR-level log record app-wide) — so downgrading only the log call
+    inside _raise_unp4k_failure wasn't enough; the worker's own logging needed
+    the same treatment, and needed a reliable way to recognize this case."""
+
+
 def _raise_unp4k_failure(returncode: int, output: str) -> None:
-    """Raise a RuntimeError for a non-zero unp4k exit.
+    """Raise for a non-zero unp4k exit — P4kLockedError for a locked Data.p4k,
+    plain RuntimeError otherwise.
 
     Upgrades the generic "exited with code N" message to a clear "Star Citizen
     is updating, wait and retry" hint when the failure is Data.p4k being locked
@@ -49,23 +65,17 @@ def _raise_unp4k_failure(returncode: int, output: str) -> None:
     tab keeps the underlying technical detail even when the friendly message is
     shown. Never returns — always raises.
 
-    Logged at WARNING, not ERROR, for the locked-file case specifically:
-    MainWindow's global ErrorDialogHandler pops its own generic "Smart
-    Citizen — Error / Show Log / Dismiss" dialog for every ERROR-level log
-    record, anywhere in the app (error_dialog.py). That's meant for genuinely
-    unexpected failures; a locked Data.p4k is an anticipated, well-understood
-    condition with its own dedicated friendly dialog (the one this raises
-    into), so logging it at ERROR duplicated that dialog with a second,
-    confusing raw-stack-trace popup on top of it. Any OTHER unp4k failure
-    still logs at ERROR — those are genuinely unexpected and should still
-    surface through the generic handler."""
+    Logged at WARNING, not ERROR, for the locked-file case specifically — see
+    P4kLockedError's docstring for why. Any OTHER unp4k failure still logs at
+    ERROR — those are genuinely unexpected and should still surface through
+    the generic handler."""
     output = output or ""
     if _P4K_LOCKED_SIGNATURE in output.lower():
         logger.warning(
             f"unp4k.exe exited with code {returncode} — Data.p4k is locked "
             f"(game likely updating); output:\n{output[:2000]}"
         )
-        raise RuntimeError(tr("extract.p4k_locked"))
+        raise P4kLockedError(tr("extract.p4k_locked"))
     logger.error(f"unp4k.exe exited with code {returncode}; output:\n{output[:2000]}")
     raise RuntimeError(f"unp4k.exe exited with code {returncode}.\n\n{output}")
 

--- a/src/utils/pak_extractor.py
+++ b/src/utils/pak_extractor.py
@@ -29,6 +29,31 @@ P4K_SIZE_STAMP = ".p4k_size"
 # Detect once at import.
 _RMTREE_CB_KWARG = "onexc" if sys.version_info >= (3, 12) else "onerror"
 
+# The RSI Launcher holds an exclusive lock on Data.p4k while it downloads or
+# verifies a game update, so unp4k (which opens Data.p4k directly) dies with a
+# .NET IOException whose message contains "being used by another process"
+# (exit code 0xE0434352 = 3762504530, the generic managed-exception code — so
+# the message text, not the code, is the reliable signal). Detect it and give
+# the user a plain "your install is updating, wait and retry" hint instead of
+# a raw stack trace.
+_P4K_LOCKED_SIGNATURE = "being used by another process"
+
+
+def _raise_unp4k_failure(returncode: int, output: str) -> None:
+    """Raise a RuntimeError for a non-zero unp4k exit.
+
+    Upgrades the generic "exited with code N" message to a clear "Star Citizen
+    is updating, wait and retry" hint when the failure is Data.p4k being locked
+    by another process (the common case — the user launched an extract while
+    the RSI Launcher was patching). Always logs the raw output first so the Log
+    tab keeps the underlying technical detail even when the friendly message is
+    shown. Never returns — always raises."""
+    output = output or ""
+    logger.error(f"unp4k.exe exited with code {returncode}; output:\n{output[:2000]}")
+    if _P4K_LOCKED_SIGNATURE in output.lower():
+        raise RuntimeError(tr("extract.p4k_locked"))
+    raise RuntimeError(f"unp4k.exe exited with code {returncode}.\n\n{output}")
+
 
 def robust_rmtree(path: Path, attempts: int = 6) -> None:
     """Delete *path* recursively, surviving transient Windows locks.
@@ -241,10 +266,7 @@ def extract_global_ini(
         )
 
         if result.returncode != 0:
-            logger.error(f"unp4k stderr: {result.stderr}")
-            raise RuntimeError(
-                f"unp4k.exe exited with code {result.returncode}.\n\n{result.stderr or result.stdout}"
-            )
+            _raise_unp4k_failure(result.returncode, result.stderr or result.stdout)
 
         extracted = Path(tmp_dir) / _GLOBAL_INI_RELATIVE
         if not extracted.exists():
@@ -329,7 +351,7 @@ def extract_dataforge(
             **_get_subprocess_kwargs()
         )
         if result.returncode != 0:
-            raise RuntimeError(f"unp4k.exe failed (code {result.returncode}):\n{result.stderr or result.stdout}")
+            _raise_unp4k_failure(result.returncode, result.stderr or result.stdout)
 
         # Explicit cleanup: ensure subprocess is fully released
         del result

--- a/tests/test_pak_extraction.py
+++ b/tests/test_pak_extraction.py
@@ -20,9 +20,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 from utils.pak_extractor import (
     DATAFORGE_KEEP_SUBPATHS,
     _copy_filtered_records,
+    _raise_unp4k_failure,
     dataforge_cache_is_fresh,
     extract_dataforge,
 )
+from utils.i18n import set_language, tr
 
 
 class TestDataForgeCache:
@@ -589,3 +591,48 @@ class TestCopyFilteredRecords:
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])
+
+
+class TestUnp4kFailureMessage:
+    """_raise_unp4k_failure upgrades a locked-Data.p4k failure (RSI Launcher
+    updating) to a friendly hint, and otherwise preserves the raw output.
+
+    The lock manifests as a .NET IOException '...being used by another
+    process' with exit code 3762504530 (0xE0434352, the generic managed-
+    exception code — so the message text, not the code, is what we match on."""
+
+    _REAL_LOCK_STDERR = (
+        "Unhandled exception. System.IO.IOException: The process cannot access "
+        "the file 'E:\Games\...\StarCitizen\HOTFIX\Data.p4k' because it is "
+        "being used by another process.\n   at Microsoft.Win32.SafeHandles..."
+    )
+
+    def setup_method(self):
+        set_language("english")
+
+    def test_locked_file_raises_friendly_message(self):
+        with pytest.raises(RuntimeError) as exc:
+            _raise_unp4k_failure(3762504530, self._REAL_LOCK_STDERR)
+        assert str(exc.value) == tr("extract.p4k_locked")
+        # The friendly text must not leak the raw stack trace.
+        assert "IOException" not in str(exc.value)
+        assert "System.IO" not in str(exc.value)
+
+    def test_detection_is_case_insensitive(self):
+        with pytest.raises(RuntimeError) as exc:
+            _raise_unp4k_failure(1, "BEING USED BY ANOTHER PROCESS")
+        assert str(exc.value) == tr("extract.p4k_locked")
+
+    def test_other_failure_preserves_raw_output(self):
+        raw = "some other unp4k error: bad archive header"
+        with pytest.raises(RuntimeError) as exc:
+            _raise_unp4k_failure(2, raw)
+        msg = str(exc.value)
+        assert "exited with code 2" in msg
+        assert raw in msg
+        assert msg != tr("extract.p4k_locked")
+
+    def test_empty_output_does_not_crash(self):
+        with pytest.raises(RuntimeError) as exc:
+            _raise_unp4k_failure(-1, None)
+        assert "exited with code -1" in str(exc.value)

--- a/tests/test_pak_extraction.py
+++ b/tests/test_pak_extraction.py
@@ -9,6 +9,7 @@ Tests cover:
 """
 
 import pytest
+import logging
 import tempfile
 import os
 from pathlib import Path
@@ -631,6 +632,27 @@ class TestUnp4kFailureMessage:
         assert "exited with code 2" in msg
         assert raw in msg
         assert msg != tr("extract.p4k_locked")
+
+    def test_locked_file_logs_at_warning_not_error(self, caplog):
+        """The locked-file case must log below ERROR: MainWindow's global
+        ErrorDialogHandler pops its own generic crash-style dialog for every
+        ERROR-level record anywhere in the app, which would duplicate the
+        friendly dialog this raises into with a second, raw-stack-trace
+        popup on top of it (the exact bug this regression-guards)."""
+        with caplog.at_level(logging.WARNING, logger="utils.pak_extractor"):
+            with pytest.raises(RuntimeError):
+                _raise_unp4k_failure(3762504530, self._REAL_LOCK_STDERR)
+        assert not any(r.levelno >= logging.ERROR for r in caplog.records)
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_other_failure_logs_at_error(self, caplog):
+        """A genuinely unexpected unp4k failure should still surface through
+        the global ErrorDialogHandler — only the well-understood locked-file
+        case is downgraded."""
+        with caplog.at_level(logging.WARNING, logger="utils.pak_extractor"):
+            with pytest.raises(RuntimeError):
+                _raise_unp4k_failure(2, "some other unp4k error")
+        assert any(r.levelno >= logging.ERROR for r in caplog.records)
 
     def test_empty_output_does_not_crash(self):
         with pytest.raises(RuntimeError) as exc:

--- a/tests/test_pak_extraction.py
+++ b/tests/test_pak_extraction.py
@@ -20,6 +20,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
 from utils.pak_extractor import (
     DATAFORGE_KEEP_SUBPATHS,
+    P4kLockedError,
     _copy_filtered_records,
     _raise_unp4k_failure,
     dataforge_cache_is_fresh,
@@ -603,8 +604,8 @@ class TestUnp4kFailureMessage:
     exception code — so the message text, not the code, is what we match on."""
 
     _REAL_LOCK_STDERR = (
-        "Unhandled exception. System.IO.IOException: The process cannot access "
-        "the file 'E:\Games\...\StarCitizen\HOTFIX\Data.p4k' because it is "
+        r"Unhandled exception. System.IO.IOException: The process cannot access "
+        r"the file 'E:\Games\...\StarCitizen\HOTFIX\Data.p4k' because it is "
         "being used by another process.\n   at Microsoft.Win32.SafeHandles..."
     )
 
@@ -612,15 +613,23 @@ class TestUnp4kFailureMessage:
         set_language("english")
 
     def test_locked_file_raises_friendly_message(self):
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(P4kLockedError) as exc:
             _raise_unp4k_failure(3762504530, self._REAL_LOCK_STDERR)
         assert str(exc.value) == tr("extract.p4k_locked")
         # The friendly text must not leak the raw stack trace.
         assert "IOException" not in str(exc.value)
         assert "System.IO" not in str(exc.value)
 
+    def test_locked_file_raises_the_typed_exception(self):
+        """Must be P4kLockedError specifically, not a plain RuntimeError —
+        the worker except blocks (workers.py) key off isinstance() to decide
+        whether to log at WARNING (this case) or ERROR (any other failure),
+        so the type distinction is what prevents the duplicate-dialog bug."""
+        with pytest.raises(P4kLockedError):
+            _raise_unp4k_failure(3762504530, self._REAL_LOCK_STDERR)
+
     def test_detection_is_case_insensitive(self):
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(P4kLockedError) as exc:
             _raise_unp4k_failure(1, "BEING USED BY ANOTHER PROCESS")
         assert str(exc.value) == tr("extract.p4k_locked")
 
@@ -632,6 +641,14 @@ class TestUnp4kFailureMessage:
         assert "exited with code 2" in msg
         assert raw in msg
         assert msg != tr("extract.p4k_locked")
+
+    def test_other_failure_is_not_the_locked_type(self):
+        """A genuine failure must NOT be P4kLockedError, or the worker would
+        wrongly log it at WARNING and skip the global error-dialog handler
+        for a real, unexpected problem."""
+        with pytest.raises(RuntimeError) as exc:
+            _raise_unp4k_failure(2, "some other unp4k error")
+        assert not isinstance(exc.value, P4kLockedError)
 
     def test_locked_file_logs_at_warning_not_error(self, caplog):
         """The locked-file case must log below ERROR: MainWindow's global


### PR DESCRIPTION
Stacks on #252 (i18n hardcoded-string sweep) — this uses the `extract.*` i18n keys and tr()-based error dialogs that PR introduces; the extraction error dialogs are still hardcoded English on plain `release/2.3.0`.

## Problem
Extracting the base.ini or DataForge cache while the RSI Launcher is downloading/verifying a game update failed with a raw .NET stack trace: `unp4k.exe exited with code 3762504530 ... System.IO.IOException: The process cannot access the file '...Data.p4k' because it is being used by another process.` The launcher holds an exclusive lock on `Data.p4k` during a patch, and unp4k opens it directly.

## Fix
- The exit code (`0xE0434352`) is just the generic .NET managed-exception code, so detection keys off the message text `"being used by another process"`.
- Added `P4kLockedError(RuntimeError)` so both unp4k call sites (`extract_global_ini`, `extract_dataforge`) can raise a distinct, typed exception for this case instead of a plain `RuntimeError`.
- When matched, raises `P4kLockedError` with a plain, actionable message: "Star Citizen appears to be updating right now. Its game files (Data.p4k) are locked by another program, usually the RSI Launcher downloading or verifying an update. Wait until all updates and verification finish in the RSI Launcher, then try again." New i18n key `extract.p4k_locked` (English text; empty FR/PT-BR/ES stubs fall back to English).
- **Avoiding a duplicate popup:** `P4kExtractWorker`/`DataForgeExtractWorker` each wrap their extraction call in a blanket `except Exception: logger.exception(...)`, which logs at ERROR unconditionally and independently triggers MainWindow's global `ErrorDialogHandler` (any ERROR-level log record, app-wide) — so the friendly dialog was popping up *twice*, once from the worker's generic handler and once from the intended one. Both workers now catch `P4kLockedError` before the generic handler and log it at `WARNING` instead (full detail is already logged by `_raise_unp4k_failure`) — the `error` signal still fires and the friendly dialog still shows, just without the duplicate. Any other unp4k failure is still a plain `RuntimeError` and still correctly triggers the generic handler.

## Testing
Built portables through several iterations of this fix (the duplicate-dialog bug took two passes to actually fix — the log-level downgrade inside the extraction helper alone wasn't enough, since the workers' own blanket exception handler independently logged at ERROR). Reporter confirmed on a real RSI Launcher update that the locked-file scenario now shows exactly one friendly dialog. 36 tests in `test_pak_extraction.py` (added: typed-exception assertions, log-level assertions for both the locked and non-locked cases).