### PR TITLE
docs: update Spanish HELP.md for the second-line watermark wording

### DIFF
--- a/languages/spanish/HELP.md
+++ b/languages/spanish/HELP.md
@@ -76,7 +76,7 @@ Haz clic en **Aplicar mejoras** para escribir tus ediciones en la instalación d
 
 El color del botón te dice en qué punto estás: **rojo** significa que algo ha cambiado desde tu última aplicación (una edición, una regeneración, un cambio de idioma o de canal) y el juego aún no lo tiene; **verde** significa que el juego ya coincide con lo cargado, y el botón queda desactivado porque no hay nada que rehacer. La misma convención rojo/verde se aplica a **Generar mejoras** y **Aplicar cambios de etiquetas** en la pestaña Mejoras. Si cierras la aplicación con el botón Aplicar todavía en rojo, Smart Citizen te pregunta si aplicar ahora o salir sin aplicar, para que el trabajo sin aplicar nunca se pierda en silencio.
 
-Smart Citizen también estampa una pequeña marca de agua en el texto de versión del lanzador (`Frontend_PU_Version`), añadiendo `| Localizations Enhanced with Smart Citizen v{VERSION}`. Así confirmas en el juego que tu loc-pack está activo: mira la etiqueta de versión en el menú principal de Star Citizen. La marca se reescribe con cada aplicación, así que nunca se acumula entre versiones.
+Smart Citizen también estampa una pequeña marca de agua en el texto de versión del lanzador (`Frontend_PU_Version`), añadiendo `\nLocalizations Enhanced with Smart Citizen v{VERSION}` en su propia línea. Así confirmas en el juego que tu loc-pack está activo: mira la etiqueta de versión en el menú principal de Star Citizen. La marca se reescribe con cada aplicación, así que nunca se acumula entre versiones.
 
 ## 8. Restaurar una copia de seguridad
 


### PR DESCRIPTION
Small follow-up to #304 (frontend version watermark moved to its own line). Stacks on #254 (translated docs backfill) since Spanish HELP.md doesn't exist until that PR — this couldn't land as part of #304 directly.

Same inline code-literal tweak as the English/French/Portuguese-BR docs in #304 — wording only, no functional change.