### PR TITLE
Add Export / Import Settings backup

### DIFF
--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -98,7 +98,7 @@ Use **Reset user.ini** in the **Config** tab to wipe all of your personal edits 
 
 ## 13. Export / Import Settings
 
-Use **Export Settings** and **Import Settings** in the **Config** tab to move your whole Smart Citizen setup between PCs, or back it up before a fresh install. Export bundles your app settings and every channel's `user.ini` overrides into one small zip; secrets and machine-specific paths (your Star Citizen install path, window geometry) are left out. Import layers that backup over your current settings and replaces `user.ini` for the channels it contains — your current `user.ini` files are snapshotted first via **Restore user.ini**, so an import is reversible. Smart Citizen restarts after an import to load the new settings, then offers to regenerate and apply your enhancements.
+Use **Export Settings** and **Import Settings** in the **Config** tab to move your whole Smart Citizen setup between PCs, or back it up before a fresh install. Export bundles your app settings and every channel's `user.ini` overrides into one small zip, including your Star Citizen install path; machine-specific paths that wouldn't make sense on another PC (your data folder, cache location, window geometry) are left out. Import layers that backup over your current settings and replaces `user.ini` for the channels it contains — your current `user.ini` files are snapshotted first via **Restore user.ini**, so an import is reversible. Your Star Citizen path is only kept if it still exists on the PC you're importing to; otherwise Smart Citizen auto-detects it instead. Smart Citizen restarts after an import to load the new settings, then offers to regenerate and apply your enhancements.
 
 ## 14. After Game Updates
 

--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -96,11 +96,15 @@ Open the **More** menu and choose **Export INI…** to bundle the currently appl
 
 Use **Reset user.ini** in the **Config** tab to wipe all of your personal edits for the active channel. A confirmation prompt makes sure it isn't a mis-click, and an automatic backup of the current `user.ini` is taken into `<data folder>\<channel>\backups\` first — so a reset is recoverable if you change your mind.
 
-## 13. After Game Updates
+## 13. Export / Import Settings
+
+Use **Export Settings** and **Import Settings** in the **Config** tab to move your whole Smart Citizen setup between PCs, or back it up before a fresh install. Export bundles your app settings and every channel's `user.ini` overrides into one small zip; secrets and machine-specific paths (your Star Citizen install path, window geometry) are left out. Import layers that backup over your current settings and replaces `user.ini` for the channels it contains — your current `user.ini` files are snapshotted first via **Restore user.ini**, so an import is reversible. Smart Citizen restarts after an import to load the new settings, then offers to regenerate and apply your enhancements.
+
+## 14. After Game Updates
 
 When Star Citizen updates, your edits are preserved in `<data folder>\<channel>\user.ini`. Re-run **Extract from Data.p4k** to pull fresh stock strings from the patched game — the table reloads automatically and your customizations re-apply on top.
 
-## 14. Switch Languages
+## 15. Switch Languages
 
 Pick a language from the **Language** dropdown in the **Config** tab (next to Channel). Switching changes both the app's interface and the game strings in the table:
 
@@ -114,7 +118,7 @@ Applying writes to the matching language folder in your game install and sets `g
 
 Want to help translate? Translation status per language is tracked in `languages/TRANSLATIONS.md` in the repo, and we would much rather ship your words than a machine's. Reach out on the Discord.
 
-## 15. App Updates
+## 16. App Updates
 
 Smart Citizen checks for a new version every time it starts. When one is available, the release notes appear in a scrollable window with two choices:
 

--- a/languages/english/ui.json
+++ b/languages/english/ui.json
@@ -2539,11 +2539,19 @@
       "at": ""
     },
     "post_import_apply_title": {
-      "ht": "Apply Your Imported Settings?",
+      "ht": "Almost Done — Apply to Your Game?",
       "at": ""
     },
     "post_import_apply_body": {
-      "ht": "Your imported settings are loaded, but the game caches on this PC are fresh — enhancements need to be regenerated and applied before your customizations show up in-game. This can take a few minutes (game data is extracted first when needed).\n\nDo this now?",
+      "ht": "Your settings are imported. The last step is to build your enhancements from this PC's game files and write them into the game.\n\nBackups store your settings, not the generated game text, so this has to be done once on each new PC. It usually takes a few minutes — a little longer the first time, while your game files are unpacked.\n\nYou can also do this later with the Apply Enhancements button.",
+      "at": ""
+    },
+    "post_import_apply_now_btn": {
+      "ht": "Apply Now",
+      "at": ""
+    },
+    "post_import_apply_later_btn": {
+      "ht": "Later",
       "at": ""
     }
   }

--- a/languages/english/ui.json
+++ b/languages/english/ui.json
@@ -474,6 +474,30 @@
       "ht": "Preview Apply",
       "at": ""
     },
+    "backup_group": {
+      "ht": "Settings Backup",
+      "at": ""
+    },
+    "backup_desc": {
+      "ht": "Save all your settings — preferences, tag configurations, your Star Citizen folder, and your custom string overrides for every channel — into one small backup file. Import it on a new PC, after a fresh portable unzip, or to undo a misconfiguration. Backups work across Smart Citizen versions. Game caches are not included; they rebuild from your game files automatically.",
+      "at": ""
+    },
+    "export_settings_btn": {
+      "ht": "Export Settings...",
+      "at": ""
+    },
+    "export_settings_tooltip": {
+      "ht": "Save your preferences, Star Citizen folder, and custom string overrides to a small backup zip (a few KB). Keep it anywhere — cloud drive, USB stick — and import it later, on any Smart Citizen version, to restore your settings.",
+      "at": ""
+    },
+    "import_settings_btn": {
+      "ht": "Import Settings...",
+      "at": ""
+    },
+    "import_settings_tooltip": {
+      "ht": "Restore a settings backup zip made by any Smart Citizen version. Your current user.ini files are snapshotted first, your Star Citizen folder is restored (or auto-detected if the backup's path isn't on this PC), and Smart Citizen restarts with the imported settings.",
+      "at": ""
+    },
     "check_updates_btn": {
       "ht": "Check for Updates",
       "at": ""
@@ -1976,6 +2000,10 @@
       "ht": "Open release page for v{version}",
       "at": ""
     },
+    "settings_exported": {
+      "ht": "Settings backup exported",
+      "at": ""
+    },
     "downloading_ini": {
       "ht": "Downloading INI file...",
       "at": ""
@@ -2410,6 +2438,112 @@
     },
     "sending_status": {
       "ht": "Sending report to Discord...",
+      "at": ""
+    }
+  },
+  "settings_backup": {
+    "zip_filter": {
+      "ht": "Settings backup (*.zip)",
+      "at": ""
+    },
+    "no_channels": {
+      "ht": "none",
+      "at": ""
+    },
+    "export_dialog_title": {
+      "ht": "Export Settings Backup",
+      "at": ""
+    },
+    "export_done_title": {
+      "ht": "Settings Exported",
+      "at": ""
+    },
+    "export_done_body": {
+      "ht": "Your settings were saved to:\n{path}\n\nIncluded: {n_settings} settings and custom string overrides for: {channels}.\n\nKeep this file anywhere — it's small. Use Import Settings to restore it on a new PC or after moving to a new portable version.",
+      "at": ""
+    },
+    "export_failed_title": {
+      "ht": "Export Failed",
+      "at": ""
+    },
+    "export_failed_body": {
+      "ht": "Could not write the backup zip.\n\n{error_type}: {error}",
+      "at": ""
+    },
+    "import_dialog_title": {
+      "ht": "Import Settings Backup",
+      "at": ""
+    },
+    "import_invalid_title": {
+      "ht": "Not a Settings Backup",
+      "at": ""
+    },
+    "import_invalid_body": {
+      "ht": "This file could not be imported:\n\n{error}",
+      "at": ""
+    },
+    "import_confirm_title": {
+      "ht": "Import These Settings?",
+      "at": ""
+    },
+    "import_confirm_body": {
+      "ht": "Backup made with Smart Citizen v{version} on {when}.\n\nIt contains {n_settings} settings and string overrides for: {channels}.\n\nImporting layers these over your current settings and replaces user.ini for the listed channels (your current user.ini files are snapshotted first, so this is reversible via Restore user.ini). Continue?",
+      "at": ""
+    },
+    "import_failed_title": {
+      "ht": "Import Failed",
+      "at": ""
+    },
+    "import_failed_body": {
+      "ht": "Could not write the imported overrides.\n\n{error_type}: {error}\n\nNo settings were changed.",
+      "at": ""
+    },
+    "import_done_title": {
+      "ht": "Settings Imported",
+      "at": ""
+    },
+    "import_done_body_restored": {
+      "ht": "Imported {applied} settings and string overrides for: {channels}.\n\nYour Star Citizen folder was restored from the backup:\n{root}\n\nSmart Citizen needs to restart to load your imported settings. After the restart it will offer to regenerate and apply your enhancements.",
+      "at": ""
+    },
+    "import_done_body_detected": {
+      "ht": "Imported {applied} settings and string overrides for: {channels}.\n\nThe backup's Star Citizen folder isn't on this PC, so it was auto-detected instead:\n{root}\n\nSmart Citizen needs to restart to load your imported settings. After the restart it will offer to regenerate and apply your enhancements.",
+      "at": ""
+    },
+    "import_done_body_no_install": {
+      "ht": "Imported {applied} settings and string overrides for: {channels}.\n\nNo Star Citizen install was found on this PC — set it on the Config tab after the restart.\n\nSmart Citizen needs to restart to load your imported settings.",
+      "at": ""
+    },
+    "restart_now_btn": {
+      "ht": "Restart Now",
+      "at": ""
+    },
+    "restart_later_btn": {
+      "ht": "Restart Later",
+      "at": ""
+    },
+    "relaunch_failed_title": {
+      "ht": "Restart Failed",
+      "at": ""
+    },
+    "relaunch_failed_body": {
+      "ht": "Smart Citizen could not restart itself. Please start it again manually — your imported settings will load then.",
+      "at": ""
+    },
+    "post_import_no_install_title": {
+      "ht": "Set Your Star Citizen Folder",
+      "at": ""
+    },
+    "post_import_no_install_body": {
+      "ht": "Your imported settings are loaded, but no Star Citizen install is configured yet. Set the installation folder on the Config tab, then use Apply Enhancements to put your customizations into the game.",
+      "at": ""
+    },
+    "post_import_apply_title": {
+      "ht": "Apply Your Imported Settings?",
+      "at": ""
+    },
+    "post_import_apply_body": {
+      "ht": "Your imported settings are loaded, but the game caches on this PC are fresh — enhancements need to be regenerated and applied before your customizations show up in-game. This can take a few minutes (game data is extracted first when needed).\n\nDo this now?",
       "at": ""
     }
   }

--- a/languages/french/ui.json
+++ b/languages/french/ui.json
@@ -801,6 +801,30 @@
     "language_source_placeholder": {
       "ht": "",
       "at": "https://…/global.ini"
+    },
+    "backup_group": {
+      "ht": "",
+      "at": "Sauvegarde des parametres"
+    },
+    "backup_desc": {
+      "ht": "",
+      "at": "Enregistrez tous vos parametres (preferences, configurations d'etiquettes, votre dossier Star Citizen et vos modifications de texte personnalisees pour chaque canal) dans un seul petit fichier de sauvegarde. Importez-le sur un nouveau PC, apres une extraction portable fraiche, ou pour annuler une mauvaise configuration. Les sauvegardes fonctionnent entre les versions de Smart Citizen. Les caches du jeu ne sont pas inclus ; ils se reconstruisent automatiquement a partir de vos fichiers de jeu."
+    },
+    "export_settings_btn": {
+      "ht": "",
+      "at": "Exporter les parametres..."
+    },
+    "export_settings_tooltip": {
+      "ht": "",
+      "at": "Enregistrez vos preferences, votre dossier Star Citizen et vos modifications de texte personnalisees dans un petit fichier zip de sauvegarde (quelques Ko). Conservez-le n'importe ou (drive cloud, cle USB) et importez-le plus tard, sur n'importe quelle version de Smart Citizen, pour restaurer vos parametres."
+    },
+    "import_settings_btn": {
+      "ht": "",
+      "at": "Importer les parametres..."
+    },
+    "import_settings_tooltip": {
+      "ht": "",
+      "at": "Restaurez un fichier de sauvegarde des parametres cree par n'importe quelle version de Smart Citizen. Vos fichiers user.ini actuels sont d'abord photographies, votre dossier Star Citizen est restaure (ou detecte automatiquement si le chemin de la sauvegarde n'est pas sur ce PC), et Smart Citizen redemarre avec les parametres importes."
     }
   },
   "enhancements": {
@@ -2055,6 +2079,10 @@
     "manifest_missing": {
       "ht": "",
       "at": "SC {channel} (manifeste manquant)"
+    },
+    "settings_exported": {
+      "ht": "",
+      "at": "Sauvegarde des parametres exportee"
     }
   },
   "import_flow": {
@@ -2603,6 +2631,120 @@
         "ht": "",
         "at": "Marquez les plans que vous possédez. Cherchez dans la liste de gauche par nom ou par mission, ou affinez par Type, Classe, Taille et Grade de composant, puis utilisez les flèches pour déplacer des éléments vers votre liste de possédés. Les plans possédés reçoivent une étiquette [Owned] partout où ils apparaissent dans les récompenses potentielles d'une mission, pour voir d'un coup d'œil ce qui vaut la peine d'être chassé."
       }
+    }
+  },
+  "settings_backup": {
+    "export_dialog_title": {
+      "ht": "",
+      "at": "Exporter la sauvegarde des parametres"
+    },
+    "export_done_title": {
+      "ht": "",
+      "at": "Parametres exportes"
+    },
+    "export_done_body": {
+      "ht": "",
+      "at": "Vos parametres ont ete enregistres dans :\n{path}\n\nInclus : {n_settings} parametres et modifications de texte personnalisees pour : {channels}.\n\nConservez ce fichier n'importe ou, il est petit. Utilisez Importer les parametres pour le restaurer sur un nouveau PC ou apres etre passe a une nouvelle version portable."
+    },
+    "export_failed_title": {
+      "ht": "",
+      "at": "Echec de l'exportation"
+    },
+    "export_failed_body": {
+      "ht": "",
+      "at": "Impossible d'ecrire le fichier zip de sauvegarde.\n\n{error_type} : {error}"
+    },
+    "import_dialog_title": {
+      "ht": "",
+      "at": "Importer la sauvegarde des parametres"
+    },
+    "import_confirm_title": {
+      "ht": "",
+      "at": "Importer ces parametres ?"
+    },
+    "import_confirm_body": {
+      "ht": "",
+      "at": "Sauvegarde creee avec Smart Citizen v{version} le {when}.\n\nElle contient {n_settings} parametres et modifications de texte pour : {channels}.\n\nL'importation superpose ces donnees a vos parametres actuels et remplace user.ini pour les canaux listes (vos fichiers user.ini actuels sont d'abord photographies, donc c'est reversible via Reinitialiser user.ini). Continuer ?"
+    },
+    "import_done_title": {
+      "ht": "",
+      "at": "Parametres importes"
+    },
+    "import_done_body_detected": {
+      "ht": "",
+      "at": "{applied} parametres et modifications de texte importes pour : {channels}.\n\nLe dossier Star Citizen de la sauvegarde n'est pas sur ce PC, il a donc ete detecte automatiquement a la place :\n{root}\n\nSmart Citizen doit redemarrer pour charger vos parametres importes. Apres le redemarrage, il proposera de regenerer et d'appliquer vos ameliorations."
+    },
+    "import_done_body_no_install": {
+      "ht": "",
+      "at": "{applied} parametres et modifications de texte importes pour : {channels}.\n\nAucune installation de Star Citizen n'a ete trouvee sur ce PC ; definissez-la dans l'onglet Configuration apres le redemarrage.\n\nSmart Citizen doit redemarrer pour charger vos parametres importes."
+    },
+    "import_done_body_restored": {
+      "ht": "",
+      "at": "{applied} parametres et modifications de texte importes pour : {channels}.\n\nVotre dossier Star Citizen a ete restaure depuis la sauvegarde :\n{root}\n\nSmart Citizen doit redemarrer pour charger vos parametres importes. Apres le redemarrage, il proposera de regenerer et d'appliquer vos ameliorations."
+    },
+    "import_failed_title": {
+      "ht": "",
+      "at": "Echec de l'importation"
+    },
+    "import_failed_body": {
+      "ht": "",
+      "at": "Impossible d'ecrire les modifications importees.\n\n{error_type} : {error}\n\nAucun parametre n'a ete modifie."
+    },
+    "import_invalid_title": {
+      "ht": "",
+      "at": "Ce n'est pas une sauvegarde de parametres"
+    },
+    "import_invalid_body": {
+      "ht": "",
+      "at": "Ce fichier n'a pas pu etre importe :\n\n{error}"
+    },
+    "no_channels": {
+      "ht": "",
+      "at": "aucun"
+    },
+    "post_import_apply_title": {
+      "ht": "",
+      "at": "Presque termine — appliquer a votre jeu ?"
+    },
+    "post_import_apply_body": {
+      "ht": "",
+      "at": "Vos parametres sont importes. La derniere etape consiste a construire vos ameliorations a partir des fichiers de jeu de ce PC et a les ecrire dans le jeu.\n\nLes sauvegardes stockent vos parametres, pas le texte de jeu genere, donc cela doit etre fait une fois sur chaque nouveau PC. Cela prend generalement quelques minutes, un peu plus longtemps la premiere fois, le temps que vos fichiers de jeu soient decompresses.\n\nVous pouvez aussi le faire plus tard avec le bouton Appliquer les ameliorations."
+    },
+    "post_import_apply_now_btn": {
+      "ht": "",
+      "at": "Appliquer maintenant"
+    },
+    "post_import_apply_later_btn": {
+      "ht": "",
+      "at": "Plus tard"
+    },
+    "post_import_no_install_title": {
+      "ht": "",
+      "at": "Definissez votre dossier Star Citizen"
+    },
+    "post_import_no_install_body": {
+      "ht": "",
+      "at": "Vos parametres importes sont charges, mais aucune installation de Star Citizen n'est encore configuree. Definissez le dossier d'installation dans l'onglet Configuration, puis utilisez Appliquer les ameliorations pour mettre vos personnalisations dans le jeu."
+    },
+    "relaunch_failed_title": {
+      "ht": "",
+      "at": "Echec du redemarrage"
+    },
+    "relaunch_failed_body": {
+      "ht": "",
+      "at": "Smart Citizen n'a pas pu se relancer. Veuillez le redemarrer manuellement ; vos parametres importes se chargeront alors."
+    },
+    "restart_now_btn": {
+      "ht": "",
+      "at": "Redemarrer maintenant"
+    },
+    "restart_later_btn": {
+      "ht": "",
+      "at": "Redemarrer plus tard"
+    },
+    "zip_filter": {
+      "ht": "",
+      "at": "Sauvegarde des parametres (*.zip)"
     }
   }
 }

--- a/languages/portuguese_br/ui.json
+++ b/languages/portuguese_br/ui.json
@@ -801,6 +801,30 @@
     "language_source_placeholder": {
       "ht": "",
       "at": "https://…/global.ini"
+    },
+    "backup_group": {
+      "ht": "",
+      "at": "Backup de Configuracoes"
+    },
+    "backup_desc": {
+      "ht": "",
+      "at": "Salve todas as suas configuracoes (preferencias, configuracoes de tags, sua pasta do Star Citizen e suas substituicoes de texto personalizadas para cada canal) em um unico arquivo de backup pequeno. Importe em um PC novo, apos descompactar uma versao portatil nova, ou para desfazer uma configuracao errada. Os backups funcionam entre versoes do Smart Citizen. Os caches do jogo nao sao incluidos; eles se reconstroem automaticamente a partir dos arquivos do seu jogo."
+    },
+    "export_settings_btn": {
+      "ht": "",
+      "at": "Exportar Configuracoes..."
+    },
+    "export_settings_tooltip": {
+      "ht": "",
+      "at": "Salve suas preferencias, pasta do Star Citizen e substituicoes de texto personalizadas em um pequeno zip de backup (poucos KB). Guarde onde quiser (nuvem, pendrive) e importe depois, em qualquer versao do Smart Citizen, para restaurar suas configuracoes."
+    },
+    "import_settings_btn": {
+      "ht": "",
+      "at": "Importar Configuracoes..."
+    },
+    "import_settings_tooltip": {
+      "ht": "",
+      "at": "Restaura um zip de backup de configuracoes feito por qualquer versao do Smart Citizen. Seus arquivos user.ini atuais sao capturados primeiro, sua pasta do Star Citizen e restaurada (ou detectada automaticamente se o caminho do backup nao estiver neste PC), e o Smart Citizen reinicia com as configuracoes importadas."
     }
   },
   "enhancements": {
@@ -2055,6 +2079,10 @@
     "manifest_missing": {
       "ht": "",
       "at": "SC {channel} (manifesto ausente)"
+    },
+    "settings_exported": {
+      "ht": "",
+      "at": "Backup de configuracoes exportado"
     }
   },
   "import_flow": {
@@ -2603,6 +2631,120 @@
         "ht": "",
         "at": "Marque os blueprints que você possui. Busque na lista da esquerda por nome ou missão, ou refine por Tipo, Classe, Tamanho e Grau de componente, e então use as setas para mover itens para a sua lista de adquiridos. Blueprints adquiridos recebem uma tag [Owned] onde quer que apareçam nas recompensas potenciais de uma missão, para você ver de relance o que ainda vale caçar."
       }
+    }
+  },
+  "settings_backup": {
+    "export_dialog_title": {
+      "ht": "",
+      "at": "Exportar Backup de Configuracoes"
+    },
+    "export_done_title": {
+      "ht": "",
+      "at": "Configuracoes Exportadas"
+    },
+    "export_done_body": {
+      "ht": "",
+      "at": "Suas configuracoes foram salvas em:\n{path}\n\nIncluido: {n_settings} configuracoes e substituicoes de texto personalizadas para: {channels}.\n\nGuarde este arquivo onde quiser, ele e pequeno. Use Importar Configuracoes para restaura-lo em um PC novo ou apos migrar para uma nova versao portatil."
+    },
+    "export_failed_title": {
+      "ht": "",
+      "at": "Falha ao Exportar"
+    },
+    "export_failed_body": {
+      "ht": "",
+      "at": "Nao foi possivel gravar o zip de backup.\n\n{error_type}: {error}"
+    },
+    "import_dialog_title": {
+      "ht": "",
+      "at": "Importar Backup de Configuracoes"
+    },
+    "import_confirm_title": {
+      "ht": "",
+      "at": "Importar estas configuracoes?"
+    },
+    "import_confirm_body": {
+      "ht": "",
+      "at": "Backup feito com Smart Citizen v{version} em {when}.\n\nContem {n_settings} configuracoes e substituicoes de texto para: {channels}.\n\nImportar sobrepoe isso as suas configuracoes atuais e substitui o user.ini dos canais listados (seus arquivos user.ini atuais sao capturados primeiro, entao isso e reversivel via Redefinir user.ini). Continuar?"
+    },
+    "import_done_title": {
+      "ht": "",
+      "at": "Configuracoes Importadas"
+    },
+    "import_done_body_detected": {
+      "ht": "",
+      "at": "{applied} configuracoes e substituicoes de texto importadas para: {channels}.\n\nA pasta do Star Citizen do backup nao esta neste PC, entao foi detectada automaticamente:\n{root}\n\nO Smart Citizen precisa reiniciar para carregar suas configuracoes importadas. Apos reiniciar, ele oferecera para regenerar e aplicar seus aprimoramentos."
+    },
+    "import_done_body_no_install": {
+      "ht": "",
+      "at": "{applied} configuracoes e substituicoes de texto importadas para: {channels}.\n\nNenhuma instalacao do Star Citizen foi encontrada neste PC; defina-a na aba Configuracao apos reiniciar.\n\nO Smart Citizen precisa reiniciar para carregar suas configuracoes importadas."
+    },
+    "import_done_body_restored": {
+      "ht": "",
+      "at": "{applied} configuracoes e substituicoes de texto importadas para: {channels}.\n\nSua pasta do Star Citizen foi restaurada a partir do backup:\n{root}\n\nO Smart Citizen precisa reiniciar para carregar suas configuracoes importadas. Apos reiniciar, ele oferecera para regenerar e aplicar seus aprimoramentos."
+    },
+    "import_failed_title": {
+      "ht": "",
+      "at": "Falha ao Importar"
+    },
+    "import_failed_body": {
+      "ht": "",
+      "at": "Nao foi possivel gravar as substituicoes importadas.\n\n{error_type}: {error}\n\nNenhuma configuracao foi alterada."
+    },
+    "import_invalid_title": {
+      "ht": "",
+      "at": "Isto Nao e um Backup de Configuracoes"
+    },
+    "import_invalid_body": {
+      "ht": "",
+      "at": "Este arquivo nao pode ser importado:\n\n{error}"
+    },
+    "no_channels": {
+      "ht": "",
+      "at": "nenhum"
+    },
+    "post_import_apply_title": {
+      "ht": "",
+      "at": "Quase Pronto — Aplicar ao Seu Jogo?"
+    },
+    "post_import_apply_body": {
+      "ht": "",
+      "at": "Suas configuracoes foram importadas. A ultima etapa e gerar seus aprimoramentos a partir dos arquivos de jogo deste PC e grava-los no jogo.\n\nOs backups guardam suas configuracoes, nao o texto de jogo gerado, entao isso precisa ser feito uma vez em cada PC novo. Geralmente leva alguns minutos, um pouco mais na primeira vez, enquanto os arquivos do jogo sao descompactados.\n\nVoce tambem pode fazer isso depois com o botao Aplicar Aprimoramentos."
+    },
+    "post_import_apply_now_btn": {
+      "ht": "",
+      "at": "Aplicar Agora"
+    },
+    "post_import_apply_later_btn": {
+      "ht": "",
+      "at": "Depois"
+    },
+    "post_import_no_install_title": {
+      "ht": "",
+      "at": "Defina Sua Pasta do Star Citizen"
+    },
+    "post_import_no_install_body": {
+      "ht": "",
+      "at": "Suas configuracoes importadas foram carregadas, mas nenhuma instalacao do Star Citizen esta configurada ainda. Defina a pasta de instalacao na aba Configuracao e use Aplicar Aprimoramentos para colocar suas personalizacoes no jogo."
+    },
+    "relaunch_failed_title": {
+      "ht": "",
+      "at": "Falha ao Reiniciar"
+    },
+    "relaunch_failed_body": {
+      "ht": "",
+      "at": "O Smart Citizen nao conseguiu reiniciar sozinho. Inicie-o novamente manualmente; suas configuracoes importadas serao carregadas entao."
+    },
+    "restart_now_btn": {
+      "ht": "",
+      "at": "Reiniciar Agora"
+    },
+    "restart_later_btn": {
+      "ht": "",
+      "at": "Reiniciar Depois"
+    },
+    "zip_filter": {
+      "ht": "",
+      "at": "Backup de configuracoes (*.zip)"
     }
   }
 }

--- a/languages/spanish/ui.json
+++ b/languages/spanish/ui.json
@@ -801,6 +801,30 @@
     "language_source_placeholder": {
       "ht": "",
       "at": "https://…/global.ini"
+    },
+    "backup_group": {
+      "ht": "",
+      "at": "Copia de seguridad de ajustes"
+    },
+    "backup_desc": {
+      "ht": "",
+      "at": "Guarda todos tus ajustes (preferencias, configuraciones de etiquetas, tu carpeta de Star Citizen y tus modificaciones de texto personalizadas para cada canal) en un pequeno archivo de copia de seguridad. Importalo en un PC nuevo, tras descomprimir una version portable nueva, o para deshacer una mala configuracion. Las copias de seguridad funcionan entre versiones de Smart Citizen. Las cachés del juego no se incluyen; se reconstruyen automaticamente desde tus archivos de juego."
+    },
+    "export_settings_btn": {
+      "ht": "",
+      "at": "Exportar ajustes..."
+    },
+    "export_settings_tooltip": {
+      "ht": "",
+      "at": "Guarda tus preferencias, carpeta de Star Citizen y modificaciones de texto personalizadas en un pequeno zip de copia de seguridad (unos pocos KB). Guardalo donde quieras (nube, USB) e importalo mas tarde, en cualquier version de Smart Citizen, para restaurar tus ajustes."
+    },
+    "import_settings_btn": {
+      "ht": "",
+      "at": "Importar ajustes..."
+    },
+    "import_settings_tooltip": {
+      "ht": "",
+      "at": "Restaura un zip de copia de seguridad de ajustes creado por cualquier version de Smart Citizen. Tus archivos user.ini actuales se respaldan primero, tu carpeta de Star Citizen se restaura (o se detecta automaticamente si la ruta de la copia no esta en este PC), y Smart Citizen se reinicia con los ajustes importados."
     }
   },
   "enhancements": {
@@ -2055,6 +2079,10 @@
     "manifest_missing": {
       "ht": "",
       "at": "SC {channel} (falta el manifiesto)"
+    },
+    "settings_exported": {
+      "ht": "",
+      "at": "Copia de seguridad de ajustes exportada"
     }
   },
   "import_flow": {
@@ -2603,6 +2631,120 @@
         "ht": "",
         "at": "El botón Ayuda abre un panel lateral con la guía completa, una lista de problemas conocidos y un enlace de comentarios al canal de Discord de Smart Citizen. Eso es todo lo que necesitas para empezar. ¡Buena suerte, ciudadano!"
       }
+    }
+  },
+  "settings_backup": {
+    "export_dialog_title": {
+      "ht": "",
+      "at": "Exportar copia de seguridad de ajustes"
+    },
+    "export_done_title": {
+      "ht": "",
+      "at": "Ajustes exportados"
+    },
+    "export_done_body": {
+      "ht": "",
+      "at": "Tus ajustes se guardaron en:\n{path}\n\nIncluye: {n_settings} ajustes y modificaciones de texto personalizadas para: {channels}.\n\nGuarda este archivo donde quieras, es pequeno. Usa Importar ajustes para restaurarlo en un PC nuevo o tras pasar a una nueva version portable."
+    },
+    "export_failed_title": {
+      "ht": "",
+      "at": "Error al exportar"
+    },
+    "export_failed_body": {
+      "ht": "",
+      "at": "No se pudo escribir el zip de copia de seguridad.\n\n{error_type}: {error}"
+    },
+    "import_dialog_title": {
+      "ht": "",
+      "at": "Importar copia de seguridad de ajustes"
+    },
+    "import_confirm_title": {
+      "ht": "",
+      "at": "¿Importar estos ajustes?"
+    },
+    "import_confirm_body": {
+      "ht": "",
+      "at": "Copia de seguridad creada con Smart Citizen v{version} el {when}.\n\nContiene {n_settings} ajustes y modificaciones de texto para: {channels}.\n\nImportar superpone esto sobre tus ajustes actuales y reemplaza user.ini para los canales listados (tus archivos user.ini actuales se respaldan primero, asi que es reversible mediante Restablecer user.ini). ¿Continuar?"
+    },
+    "import_done_title": {
+      "ht": "",
+      "at": "Ajustes importados"
+    },
+    "import_done_body_detected": {
+      "ht": "",
+      "at": "Se importaron {applied} ajustes y modificaciones de texto para: {channels}.\n\nLa carpeta de Star Citizen de la copia no esta en este PC, asi que se detecto automaticamente en su lugar:\n{root}\n\nSmart Citizen necesita reiniciarse para cargar tus ajustes importados. Tras el reinicio, ofrecera regenerar y aplicar tus mejoras."
+    },
+    "import_done_body_no_install": {
+      "ht": "",
+      "at": "Se importaron {applied} ajustes y modificaciones de texto para: {channels}.\n\nNo se encontro ninguna instalacion de Star Citizen en este PC; configurala en la pestaña Configuracion tras el reinicio.\n\nSmart Citizen necesita reiniciarse para cargar tus ajustes importados."
+    },
+    "import_done_body_restored": {
+      "ht": "",
+      "at": "Se importaron {applied} ajustes y modificaciones de texto para: {channels}.\n\nTu carpeta de Star Citizen se restauro desde la copia de seguridad:\n{root}\n\nSmart Citizen necesita reiniciarse para cargar tus ajustes importados. Tras el reinicio, ofrecera regenerar y aplicar tus mejoras."
+    },
+    "import_failed_title": {
+      "ht": "",
+      "at": "Error al importar"
+    },
+    "import_failed_body": {
+      "ht": "",
+      "at": "No se pudieron escribir las modificaciones importadas.\n\n{error_type}: {error}\n\nNo se cambio ningun ajuste."
+    },
+    "import_invalid_title": {
+      "ht": "",
+      "at": "Esto no es una copia de seguridad de ajustes"
+    },
+    "import_invalid_body": {
+      "ht": "",
+      "at": "Este archivo no se pudo importar:\n\n{error}"
+    },
+    "no_channels": {
+      "ht": "",
+      "at": "ninguno"
+    },
+    "post_import_apply_title": {
+      "ht": "",
+      "at": "Casi listo: ¿aplicar a tu juego?"
+    },
+    "post_import_apply_body": {
+      "ht": "",
+      "at": "Tus ajustes estan importados. El ultimo paso es generar tus mejoras a partir de los archivos de juego de este PC y escribirlas en el juego.\n\nLas copias de seguridad guardan tus ajustes, no el texto de juego generado, asi que esto debe hacerse una vez en cada PC nuevo. Normalmente tarda unos minutos, un poco mas la primera vez, mientras se descomprimen tus archivos de juego.\n\nTambien puedes hacer esto mas tarde con el boton Aplicar mejoras."
+    },
+    "post_import_apply_now_btn": {
+      "ht": "",
+      "at": "Aplicar ahora"
+    },
+    "post_import_apply_later_btn": {
+      "ht": "",
+      "at": "Mas tarde"
+    },
+    "post_import_no_install_title": {
+      "ht": "",
+      "at": "Configura tu carpeta de Star Citizen"
+    },
+    "post_import_no_install_body": {
+      "ht": "",
+      "at": "Tus ajustes importados estan cargados, pero aun no hay ninguna instalacion de Star Citizen configurada. Configura la carpeta de instalacion en la pestaña Configuracion, y luego usa Aplicar mejoras para poner tus personalizaciones en el juego."
+    },
+    "relaunch_failed_title": {
+      "ht": "",
+      "at": "Error al reiniciar"
+    },
+    "relaunch_failed_body": {
+      "ht": "",
+      "at": "Smart Citizen no pudo reiniciarse. Por favor, inicialo de nuevo manualmente; tus ajustes importados se cargaran entonces."
+    },
+    "restart_now_btn": {
+      "ht": "",
+      "at": "Reiniciar ahora"
+    },
+    "restart_later_btn": {
+      "ht": "",
+      "at": "Reiniciar mas tarde"
+    },
+    "zip_filter": {
+      "ht": "",
+      "at": "Copia de seguridad de ajustes (*.zip)"
     }
   }
 }

--- a/src/gui/config_tab.py
+++ b/src/gui/config_tab.py
@@ -53,6 +53,11 @@ class ConfigTab(QWidget):
     # Emitted when the user picks a different language. MainWindow listens and
     # triggers a merge+reload so the table reflects the new language strings.
     language_changed = pyqtSignal(str)
+    # Emitted by the Settings Backup buttons. MainWindow owns the file
+    # dialogs, the zip I/O (src/utils/settings_profile.py), and the
+    # post-import restart flow so this tab stays presentation-only.
+    export_settings_requested = pyqtSignal()
+    import_settings_requested = pyqtSignal()
 
     def __init__(self):
         super().__init__()
@@ -361,6 +366,34 @@ class ConfigTab(QWidget):
         # Tools last, so it sits at the bottom of the Config tab.
         layout.addWidget(self._tools_group)
 
+        # ── Settings Backup (Export / Import Settings) ───────────────────────
+        self._backup_group = QGroupBox(tr("config.backup_group"))
+        backup_layout = QVBoxLayout(self._backup_group)
+
+        self._backup_desc_label = QLabel(tr("config.backup_desc"))
+        self._backup_desc_label.setProperty("role", "secondary")
+        self._backup_desc_label.setStyleSheet("font-size: 11px;")
+        self._backup_desc_label.setWordWrap(True)
+        backup_layout.addWidget(self._backup_desc_label)
+
+        backup_btn_layout = QHBoxLayout()
+
+        self._export_settings_btn = QPushButton(tr("config.export_settings_btn"))
+        self._export_settings_btn.setMaximumWidth(150)
+        self._export_settings_btn.setToolTip(tr("config.export_settings_tooltip"))
+        self._export_settings_btn.clicked.connect(self.export_settings_requested.emit)
+        backup_btn_layout.addWidget(self._export_settings_btn)
+
+        self._import_settings_btn = QPushButton(tr("config.import_settings_btn"))
+        self._import_settings_btn.setMaximumWidth(150)
+        self._import_settings_btn.setToolTip(tr("config.import_settings_tooltip"))
+        self._import_settings_btn.clicked.connect(self.import_settings_requested.emit)
+        backup_btn_layout.addWidget(self._import_settings_btn)
+
+        backup_btn_layout.addStretch()
+        backup_layout.addLayout(backup_btn_layout)
+        layout.addWidget(self._backup_group)
+
         layout.addStretch()
 
         # Host the content in a scroll area. MainWindow adds the tab widget
@@ -400,6 +433,12 @@ class ConfigTab(QWidget):
         self._preview_btn.setToolTip(tr("config.preview_apply_tooltip"))
         self._check_updates_btn.setText(tr("config.check_updates_btn"))
         self._check_updates_btn.setToolTip(tr("config.check_updates_tooltip"))
+        self._backup_group.setTitle(tr("config.backup_group"))
+        self._backup_desc_label.setText(tr("config.backup_desc"))
+        self._export_settings_btn.setText(tr("config.export_settings_btn"))
+        self._export_settings_btn.setToolTip(tr("config.export_settings_tooltip"))
+        self._import_settings_btn.setText(tr("config.import_settings_btn"))
+        self._import_settings_btn.setToolTip(tr("config.import_settings_tooltip"))
         self._appearance_group.setTitle(tr("config.appearance_group"))
         self._theme_label.setText(tr("config.theme_label"))
         self.theme_combo.setToolTip(tr("config.theme_tooltip"))

--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -950,6 +950,49 @@ class EnhancementsTab(QWidget):
             AppSettings.set_tag_annotate_mission_descs(annotate_cb.isChecked())
         logger.info("Tag Builder: saved configs for %s", ", ".join(pages))
 
+    def reload_tag_builder_from_settings(self) -> None:
+        """Re-read every Tag Builder page from settings, discarding UI state.
+
+        Import Settings rewrites the ``tag_builder/*`` keys underneath a tab
+        that was built at launch, so the on-screen pages still hold the
+        *pre-import* config. That stale state is not just cosmetic: the next
+        ``_persist_tag_builder_state()`` — reachable from Save Tag Changes,
+        Generate Enhancements, *and* Export Settings — would write it back
+        over everything the import just restored. Refreshing here keeps the
+        widgets and settings in agreement, so none of those paths can
+        resurrect the old config (and a user who picks "Restart Later" sees
+        their imported tags immediately).
+
+        Same shape as :meth:`revert_category_checkboxes`, which MainWindow
+        already calls to resync the category checkboxes from settings.
+        """
+        pages = getattr(self, "_tag_builder_pages", None)
+        if not pages:
+            return
+        for cat, page in pages.items():
+            page.apply_config(AppSettings.get_tag_config(cat))
+        annotate_cb = getattr(self, "_annotate_mission_descs_cb", None)
+        if annotate_cb is not None:
+            annotate_cb.blockSignals(True)
+            annotate_cb.setChecked(AppSettings.get_tag_annotate_mission_descs())
+            annotate_cb.blockSignals(False)
+        # apply_config emits config_changed per page, which lights the Save
+        # button — but nothing is actually unsaved here, so clear it.
+        self._set_tag_btn_dirty(False)
+        logger.info("Tag Builder: reloaded configs from settings for %s", ", ".join(pages))
+
+    def flush_pending_tag_edits(self) -> None:
+        """Persist on-screen Tag Builder edits *without* regenerating.
+
+        Same "what you see is what you save" contract as Generate
+        Enhancements (#215), for callers that need settings to match the UI
+        but must not kick off the pipeline. Export Settings uses this so a
+        backup captures the Tag Builder state the user is looking at, not
+        whatever was last committed via Save Tag Changes.
+        """
+        self._persist_tag_builder_state()
+        self._set_tag_btn_dirty(False)
+
     def _set_tag_btn_dirty(self, dirty: bool) -> None:
         """Single chokepoint for the button's enabled state, tooltip, and
         text color so none of the three can drift apart. Same enabled/
@@ -1787,9 +1830,33 @@ class _TagBuilderPage(QWidget):
     # ── Reset ────────────────────────────────────────────────────────────
 
     def _reset_to_defaults(self):
-        # Replace this page's config with a fresh default, rebuild the
-        # row list, resync separator/enclosing/placement combos + preview.
-        fresh = default_config(self.category)
+        """Reset-to-defaults button: swap in a fresh default config.
+
+        Thin wrapper over :meth:`apply_config` — ``reset_title_tags=True``
+        keeps the historical behaviour of *persisting* each General Tags
+        default (see the long comment in ``apply_config``).
+        """
+        self.apply_config(default_config(self.category), reset_title_tags=True)
+
+    def apply_config(self, cfg: TagConfig, *, reset_title_tags: bool = False):
+        """Adopt *cfg* as this page's config and resync every widget to it.
+
+        Two callers, two intents:
+
+        - **Reset to defaults** passes a fresh default config with
+          ``reset_title_tags=True``: General Tags are written back to their
+          per-field defaults *and persisted*, since Reset is an explicit
+          user action on that immediately-saved settings domain.
+        - **Import Settings** passes the freshly-imported saved config with
+          ``reset_title_tags=False``: the checkboxes are re-read from the
+          (already imported) settings and nothing is written back. Without
+          this refresh the page keeps the pre-import config in memory, and
+          the next Save Tag Changes / Generate / Export would write that
+          stale state straight over the imported one.
+        """
+        # Replace this page's config, rebuild the row list, resync
+        # separator/enclosing/placement combos + preview.
+        fresh = cfg
         self.config = fresh
         if self.category == "mission_titles":
             route_el = next((e for e in fresh.elements if e.kind == "route"), None)
@@ -1816,10 +1883,20 @@ class _TagBuilderPage(QWidget):
             # signal (a checkbox already at its default wouldn't fire it,
             # leaving a stale saved value if one had somehow drifted out of
             # sync).
+            _tt_saved = AppSettings.get_mission_title_tags()
             for field, box in self._title_tag_checkboxes.items():
-                default = AppSettings.get_mission_title_tag_default(field)
-                box.setChecked(default)
-                AppSettings.set_mission_title_tag(field, default)
+                if reset_title_tags:
+                    value = AppSettings.get_mission_title_tag_default(field)
+                else:
+                    # Import path: settings already hold the imported values;
+                    # just mirror them. Writing here would be a no-op at best
+                    # and could clobber at worst.
+                    value = _tt_saved.get(field, True)
+                box.blockSignals(True)
+                box.setChecked(value)
+                box.blockSignals(False)
+                if reset_title_tags:
+                    AppSettings.set_mission_title_tag(field, value)
             self._set_mt_controls_enabled(self._mt_enable.isChecked())
             self._refresh_preview()
             self.config_changed.emit()

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -2549,14 +2549,25 @@ class MainWindow(QMainWindow):
             self.tabs.setCurrentIndex(self._config_tab_index)
             return
 
-        reply = QMessageBox.question(
-            self,
-            tr("settings_backup.post_import_apply_title"),
-            tr("settings_backup.post_import_apply_body"),
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-            QMessageBox.StandardButton.Yes,
+        # Named buttons rather than stock Yes/No: "Apply Now" / "Later" says
+        # what each choice does without the body having to end in a question,
+        # and "Later" reads as a real option rather than a refusal (declining
+        # is fine — the Apply Enhancements button does the same thing).
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Question)
+        box.setWindowTitle(tr("settings_backup.post_import_apply_title"))
+        box.setText(tr("settings_backup.post_import_apply_body"))
+        apply_btn = box.addButton(
+            tr("settings_backup.post_import_apply_now_btn"),
+            QMessageBox.ButtonRole.AcceptRole,
         )
-        if reply != QMessageBox.StandardButton.Yes:
+        box.addButton(
+            tr("settings_backup.post_import_apply_later_btn"),
+            QMessageBox.ButtonRole.RejectRole,
+        )
+        box.setDefaultButton(apply_btn)
+        box.exec()
+        if box.clickedButton() is not apply_btn:
             return
 
         if self._enhancements_worker is not None or self._forge_worker is not None:

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -321,6 +321,11 @@ class MainWindow(QMainWindow):
         # apply_to_game. Cleared on completion or any failure.
         self._simple_run_active = False
 
+        # Import Settings: True while closing for the post-import restart, so
+        # closeEvent neither nags about unapplied edits nor autosaves the
+        # in-memory user.ini over the files the import just wrote.
+        self._suppress_user_ini_autosave = False
+
         # #157: item names (normalized) that appear in any POTENTIAL BLUEPRINTS
         # list — the rows eligible for the Owned star. Recomputed on each load.
         self._bp_item_names: set[str] = set()
@@ -413,6 +418,8 @@ class MainWindow(QMainWindow):
         self.config_tab.check_updates_requested.connect(self._on_check_updates_clicked)
         self.config_tab.data_dir_changed.connect(self._on_data_dir_changed)
         self.config_tab.cache_dir_changed.connect(self._on_cache_dir_changed)
+        self.config_tab.export_settings_requested.connect(self._handle_export_settings)
+        self.config_tab.import_settings_requested.connect(self._handle_import_settings)
         self._config_tab_index = self.tabs.addTab(self.config_tab, tr("tabs.config"))
 
         # Enhancements tab
@@ -2315,6 +2322,249 @@ class MainWindow(QMainWindow):
             tr("restore_user_ini.restored_body", channel=channel, name=chosen.name),
         )
 
+    def _handle_export_settings(self):
+        """Export Settings: snapshot settings + per-channel user.ini into a zip.
+
+        The zip is a few KB — preferences and string overrides only, never
+        the regenerable cache. Works identically in registry and portable
+        builds (AppSettings.export_all_values is backend-agnostic).
+        """
+        from src.utils.settings_profile import (
+            SOURCE_MODE_PORTABLE,
+            SOURCE_MODE_REGISTRY,
+            default_backup_filename,
+            write_profile_zip,
+        )
+
+        # Flush on-screen Tag Builder edits first — same "what you see is
+        # what you save" rule Generate Enhancements follows (#215). Tag
+        # configs only reach settings via Save Tag Changes / Generate, so
+        # without this a user who tweaked tags and went straight to Export
+        # would back up their *previous* config.
+        self.enhancements_tab.flush_pending_tag_edits()
+
+        settings_values = AppSettings.export_all_values()
+        overrides = AppSettings.export_channel_overrides()
+
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            tr("settings_backup.export_dialog_title"),
+            default_backup_filename(),
+            tr("settings_backup.zip_filter"),
+        )
+        if not path:
+            return
+
+        try:
+            write_profile_zip(
+                path,
+                settings=settings_values,
+                overrides=overrides,
+                app_version=get_version(),
+                source_mode=SOURCE_MODE_PORTABLE if IS_PORTABLE else SOURCE_MODE_REGISTRY,
+            )
+        except OSError as e:
+            logger.exception(f"Export Settings failed writing {path}")
+            QMessageBox.critical(
+                self,
+                tr("settings_backup.export_failed_title"),
+                tr("settings_backup.export_failed_body",
+                   error_type=type(e).__name__, error=e),
+            )
+            return
+
+        self.statusBar().showMessage(tr("status_bar.settings_exported"), 5000)
+        QMessageBox.information(
+            self,
+            tr("settings_backup.export_done_title"),
+            tr("settings_backup.export_done_body",
+               path=path,
+               n_settings=len(settings_values),
+               channels=", ".join(sorted(overrides)) or tr("settings_backup.no_channels")),
+        )
+
+    def _handle_import_settings(self):
+        """Import Settings: restore a backup zip, then restart to load it.
+
+        Flow: pick zip → validate → confirm → snapshot current user.ini files
+        (rotating backups, so the import is reversible) → write overrides +
+        settings → re-detect the SC install (machine paths never travel in a
+        backup) → set the post-import flag so the NEXT launch offers to
+        regenerate + apply enhancements → offer restart.
+        """
+        from src.utils.settings_profile import InvalidProfileError, read_profile_zip
+        from src.utils.user_ini_manager import backup_user_ini
+
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            tr("settings_backup.import_dialog_title"),
+            "",
+            tr("settings_backup.zip_filter"),
+        )
+        if not path:
+            return
+
+        try:
+            profile = read_profile_zip(path)
+        except InvalidProfileError as e:
+            QMessageBox.critical(
+                self,
+                tr("settings_backup.import_invalid_title"),
+                tr("settings_backup.import_invalid_body", error=e),
+            )
+            return
+
+        made_with = profile.app_version or "?"
+        when = profile.exported_at.replace("T", " ") if profile.exported_at else "?"
+        channels = ", ".join(sorted(profile.overrides)) or tr("settings_backup.no_channels")
+        reply = QMessageBox.question(
+            self,
+            tr("settings_backup.import_confirm_title"),
+            tr("settings_backup.import_confirm_body",
+               version=made_with, when=when,
+               n_settings=len(profile.settings), channels=channels),
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        # Write per-channel overrides, snapshotting any existing user.ini
+        # into the channel's rotating backups first (#172 machinery) so an
+        # accidental import is recoverable.
+        try:
+            for channel, text in profile.overrides.items():
+                target = AppSettings.get_channel_user_ini_path(channel)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if target.exists():
+                    backup_user_ini(target)
+                target.write_text(text, encoding="utf-8")
+                logger.info(f"Import Settings: wrote {target}")
+        except OSError as e:
+            logger.exception("Import Settings failed writing overrides")
+            QMessageBox.critical(
+                self,
+                tr("settings_backup.import_failed_title"),
+                tr("settings_backup.import_failed_body",
+                   error_type=type(e).__name__, error=e),
+            )
+            return
+
+        applied = AppSettings.import_values(profile.settings)
+        logger.info(
+            f"Import Settings: {applied} settings applied, "
+            f"{len(profile.overrides)} channel override(s) from {path}"
+        )
+
+        # Resync widgets that cache settings at construction. Without this the
+        # Tag Builder pages still hold the pre-import config, and the next
+        # Save Tag Changes / Generate Enhancements / Export Settings would
+        # write that stale state back over what we just imported — which is
+        # exactly how imported tag configs were getting lost.
+        self.enhancements_tab.reload_tag_builder_from_settings()
+        self.enhancements_tab.revert_category_checkboxes()
+
+        # The backup carries the SC install path so a same-PC restore keeps
+        # it, but it's only trusted if the folder actually exists here —
+        # otherwise this clears it and falls back to auto-detection.
+        outcome = AppSettings.reconcile_imported_install_path()
+        resolved_root = AppSettings.get_sc_install_root()
+
+        # Next launch prompts to regenerate + apply enhancements against the
+        # imported settings (fresh cache, imported tag configs and overrides).
+        AppSettings.set_post_import_apply_pending(True)
+
+        if outcome == AppSettings.INSTALL_PATH_RESTORED:
+            body = tr("settings_backup.import_done_body_restored",
+                      applied=applied, channels=channels, root=resolved_root)
+        elif outcome == AppSettings.INSTALL_PATH_REDETECTED:
+            body = tr("settings_backup.import_done_body_detected",
+                      applied=applied, channels=channels, root=resolved_root)
+        else:
+            body = tr("settings_backup.import_done_body_no_install",
+                      applied=applied, channels=channels)
+
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Information)
+        box.setWindowTitle(tr("settings_backup.import_done_title"))
+        box.setText(body)
+        restart_btn = box.addButton(
+            tr("settings_backup.restart_now_btn"), QMessageBox.ButtonRole.AcceptRole
+        )
+        box.addButton(
+            tr("settings_backup.restart_later_btn"), QMessageBox.ButtonRole.RejectRole
+        )
+        box.setDefaultButton(restart_btn)
+        box.exec()
+
+        if box.clickedButton() is restart_btn:
+            self._relaunch_app()
+
+    def _relaunch_app(self) -> None:
+        """Restart Smart Citizen: spawn a detached copy, then close this one.
+
+        Used by Import Settings so the freshly-imported settings are what the
+        new process reads at startup. The suppress flag keeps closeEvent
+        from autosaving stale in-memory state over the imported files.
+        """
+        from PyQt6.QtCore import QProcess
+
+        self._suppress_user_ini_autosave = True
+
+        if getattr(sys, "frozen", False):
+            program, args = sys.executable, []
+        else:
+            program, args = sys.executable, [os.path.abspath(sys.argv[0])]
+        workdir = str(Path(program).resolve().parent)
+
+        if not QProcess.startDetached(program, args, workdir):
+            logger.error(f"Relaunch failed for {program} {args}")
+            QMessageBox.warning(
+                self,
+                tr("settings_backup.relaunch_failed_title"),
+                tr("settings_backup.relaunch_failed_body"),
+            )
+            # Fall through to close anyway — the user relaunches by hand and
+            # still gets the imported state + post-import prompt.
+        self.close()
+
+    def _maybe_prompt_post_import_apply(self) -> None:
+        """Offer to regenerate + apply enhancements after importing settings.
+
+        Runs once per import: the flag Import Settings left behind is cleared
+        the moment it's read, so declining just leaves the normal manual
+        Apply Enhancements path. Reuses the Simple-mode continuation
+        (#180) — generate, then apply_to_game — regardless of UI mode.
+        """
+        if not AppSettings.get_post_import_apply_pending():
+            return
+        AppSettings.set_post_import_apply_pending(False)
+
+        if not AppSettings.get_game_install_path():
+            QMessageBox.information(
+                self,
+                tr("settings_backup.post_import_no_install_title"),
+                tr("settings_backup.post_import_no_install_body"),
+            )
+            self.tabs.setCurrentIndex(self._config_tab_index)
+            return
+
+        reply = QMessageBox.question(
+            self,
+            tr("settings_backup.post_import_apply_title"),
+            tr("settings_backup.post_import_apply_body"),
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.Yes,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        if self._enhancements_worker is not None or self._forge_worker is not None:
+            return  # a pipeline is somehow already running; don't stack
+        self._simple_run_active = True
+        self.simple_page.set_busy(True)
+        self._run_enhancements_pipeline()
+
     def _handle_import_ini(self):
         """Handle Import INI button: get source, validate, resolve conflicts, merge."""
         from PyQt6.QtWidgets import (
@@ -3047,6 +3297,7 @@ class MainWindow(QMainWindow):
         self._startup_gate_pending = False
         self._start_startup_sync()
         self._maybe_warn_onedrive_data_dir()
+        self._maybe_prompt_post_import_apply()
 
     def _maybe_warn_onedrive_data_dir(self) -> None:
         """Warn once when the data root is inside a OneDrive-managed folder (#172).
@@ -4531,7 +4782,7 @@ class MainWindow(QMainWindow):
         # _apply_dirty directly since the latter also starts True at launch
         # (see its comment) — that boot-time uncertainty shouldn't nag a user
         # who hasn't touched anything this session.
-        if self._session_has_unapplied_edit:
+        if self._session_has_unapplied_edit and not self._suppress_user_ini_autosave:
             box = QMessageBox(self)
             box.setIcon(QMessageBox.Icon.Warning)
             box.setWindowTitle(tr("dialogs.unapplied_changes_title"))
@@ -4565,8 +4816,14 @@ class MainWindow(QMainWindow):
             # exit_btn: fall through to the normal close sequence below,
             # exiting without applying.
 
-        # Auto-save overrides if there are unsaved edits
-        if self.entries and not (self._loader_worker and self._loader_worker.isRunning()):
+        # Auto-save overrides if there are unsaved edits. Skipped when closing
+        # for a post-import restart — the in-memory entries reflect the OLD
+        # user.ini and would clobber the files Import Settings just wrote.
+        if (
+            self.entries
+            and not self._suppress_user_ini_autosave
+            and not (self._loader_worker and self._loader_worker.isRunning())
+        ):
             try:
                 from src.utils.user_ini_manager import save_user_ini, should_autosave_user_ini
                 user_ini_path = AppSettings.get_user_ini_path()

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -384,6 +384,47 @@ class AppSettings:
     # mission text, which always shows the tag regardless of this setting.
     BLUEPRINT_SHOW_TAGS = "blueprints/show_tags"
 
+    # Set at Import Settings time so the NEXT launch can prompt "your imported
+    # settings need enhancements regenerated + applied" once the app is fully
+    # up (the import itself ends in a restart, so the freshly-imported
+    # settings are what the pipeline reads). Cleared as soon as the prompt is
+    # shown — one-shot, never lingers.
+    POST_IMPORT_APPLY_PENDING = "post_import/apply_pending"
+
+    # Keys that never travel in an Export Settings backup: the data-root and
+    # cache overrides (pointing them at a drive that doesn't exist on the
+    # target machine would strand every path derived from them), window
+    # placement (QByteArray, monitor-specific), and legacy path keys. Keys
+    # starting with "_" (one-shot migration markers) are excluded by rule in
+    # is_profile_excluded_key, as are local (non-URL) data_sources/*/path
+    # values. The same filter runs on export AND import — defense in depth
+    # against hand-edited or older backup files.
+    #
+    # NOT excluded (deliberately): sc_install_root / game_install_path. The
+    # Star Citizen folder is the single most tedious thing to re-pick, and
+    # for the common restore (same PC, fresh portable unzip) it's already
+    # correct. It's validated on import by reconcile_imported_install_path()
+    # — kept when the folder really exists here, dropped in favour of
+    # auto-detection when it doesn't — so a backup from another machine
+    # can't strand the user on a dead path.
+    PROFILE_EXCLUDE_KEYS = frozenset({
+        "user_data_dir",
+        "UserDataDir",
+        "cache_dir",
+        "pending_cache_cleanup",
+        "window_geometry",
+        "window_state",
+        "base_global_path",
+        "vehicles_path",
+        "last_overrides_path",
+        "post_import/apply_pending",
+    })
+
+    # reconcile_imported_install_path() outcomes.
+    INSTALL_PATH_RESTORED = "restored"     # backup's path is valid here
+    INSTALL_PATH_REDETECTED = "redetected"  # backup's path was bad; found another
+    INSTALL_PATH_NONE = "none"             # nothing resolved on this machine
+
     # Settings keys - Data sources (new)
     # Prefix: data_sources/{source_name}/
     DATA_SOURCES_PREFIX = "data_sources"
@@ -2801,3 +2842,193 @@ class AppSettings:
                 logger.info(f"Created empty user.ini: {user_ini_path}")
             except Exception as e:
                 logger.error(f"Failed to create user.ini: {e}")
+
+    # ── Export / Import Settings (settings backup) ───────────────────────
+    # Backend-agnostic snapshot + restore of every stored setting, powering
+    # the Config tab's Export Settings / Import Settings buttons. The zip
+    # layout and validation live in src/utils/settings_profile.py; these
+    # methods own the backend enumeration and the machine-key filter.
+
+    @staticmethod
+    def is_profile_excluded_key(key: str, value=None) -> bool:
+        """True when *key* must not travel in a settings backup.
+
+        Three rules:
+          1. Exact members of :data:`PROFILE_EXCLUDE_KEYS` (machine-local
+             paths, window placement, legacy path keys).
+          2. Keys starting with ``_`` — one-shot migration markers; a fresh
+             target profile should run its own (idempotent) migrators.
+          3. ``data_sources/*/path`` values that are NOT URLs — post-1.0 the
+             ``global`` source path points at the local cached base.ini,
+             which is meaningless on another machine (the app re-derives it
+             on load). URL-mapped custom sources survive: they're part of
+             the user's setup and work anywhere.
+        """
+        if key in AppSettings.PROFILE_EXCLUDE_KEYS:
+            return True
+        if key.startswith("_"):
+            return True
+        if (
+            key.startswith(f"{AppSettings.DATA_SOURCES_PREFIX}/")
+            and key.endswith("/path")
+        ):
+            text = str(value) if value is not None else ""
+            if not text.lower().startswith(("http://", "https://")):
+                return True
+        return False
+
+    @staticmethod
+    def export_all_values() -> dict:
+        """Snapshot every backend key/value for a settings backup.
+
+        Works against either backend: ``QSettings.allKeys()`` (registry
+        build) or ``JsonSettings.keys()`` (portable build / tests). Values
+        that JSON can't serialise (e.g. a stray QByteArray) are skipped with
+        a warning rather than poisoning the whole export — the known binary
+        keys (window geometry/state) are already excluded by the filter.
+        """
+        import json as _json
+
+        backend = AppSettings.settings()
+        if hasattr(backend, "allKeys"):
+            keys = list(backend.allKeys())
+        else:
+            keys = backend.keys()
+
+        out: dict = {}
+        for key in keys:
+            value = backend.value(key)
+            if AppSettings.is_profile_excluded_key(key, value):
+                continue
+            try:
+                _json.dumps(value)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Export Settings: skipping non-serialisable value for key "
+                    "%r (%s)", key, type(value).__name__,
+                )
+                continue
+            out[key] = value
+        return out
+
+    @staticmethod
+    def import_values(values: dict) -> int:
+        """Write backup values into the live backend. Returns keys applied.
+
+        Runs the same machine-specific filter as export (a hand-edited or
+        pre-filter backup can't smuggle in a stale install path), writes
+        everything else verbatim, and syncs once at the end. Existing keys
+        not present in *values* are left untouched — an import layers the
+        backup over the current profile rather than wiping it, so local
+        state like the SC install path survives a same-machine restore.
+        """
+        backend = AppSettings.settings()
+        applied = 0
+        for key, value in values.items():
+            if not isinstance(key, str) or not key:
+                continue
+            if AppSettings.is_profile_excluded_key(key, value):
+                continue
+            backend.setValue(key, value)
+            applied += 1
+        backend.sync()
+        logger.info("Import Settings: applied %d settings keys", applied)
+        return applied
+
+    @staticmethod
+    def reconcile_imported_install_path() -> str:
+        """Validate a just-imported Star Citizen path against this machine.
+
+        The backup carries ``sc_install_root`` so the common restore (same
+        PC, fresh portable unzip) doesn't make the user re-pick their game
+        folder. But a backup from *another* machine can name a path that
+        doesn't exist here, so the imported value is only trusted when
+        :func:`_is_valid_sc_root` still recognises it as a real install.
+
+        When it doesn't, both path keys are cleared so
+        :meth:`get_sc_install_root` runs its normal detection chain instead
+        of leaving the user pinned to a dead path.
+
+        Returns one of :data:`INSTALL_PATH_RESTORED`,
+        :data:`INSTALL_PATH_REDETECTED`, or :data:`INSTALL_PATH_NONE`.
+        """
+        imported = AppSettings.settings().value(AppSettings.SC_INSTALL_ROOT, "")
+
+        if imported and _is_valid_sc_root(imported):
+            # Re-persist through the setter so game_install_path is derived
+            # from the active channel and can't disagree with the root.
+            AppSettings.set_sc_install_root(imported)
+            logger.info(f"Import Settings: restored SC install path {imported!r}")
+            return AppSettings.INSTALL_PATH_RESTORED
+
+        if imported:
+            logger.info(
+                f"Import Settings: backup's SC install path {imported!r} is not "
+                f"valid on this machine — falling back to auto-detection"
+            )
+        settings = AppSettings.settings()
+        settings.remove(AppSettings.SC_INSTALL_ROOT)
+        settings.remove(AppSettings.GAME_INSTALL_PATH)
+
+        detected = AppSettings.get_sc_install_root()
+        if detected:
+            logger.info(f"Import Settings: auto-detected SC install {detected!r}")
+            return AppSettings.INSTALL_PATH_REDETECTED
+        return AppSettings.INSTALL_PATH_NONE
+
+    @staticmethod
+    def get_post_import_apply_pending() -> bool:
+        """Whether imported settings are still waiting for their first
+        regenerate + apply (checked once per launch, then cleared)."""
+        return AppSettings.settings().value(
+            AppSettings.POST_IMPORT_APPLY_PENDING, False, type=bool
+        )
+
+    @staticmethod
+    def set_post_import_apply_pending(pending: bool) -> None:
+        """Set or clear the post-import "enhancements need applying" flag."""
+        if pending:
+            AppSettings.settings().setValue(
+                AppSettings.POST_IMPORT_APPLY_PENDING, True
+            )
+        else:
+            AppSettings.settings().remove(AppSettings.POST_IMPORT_APPLY_PENDING)
+
+    @staticmethod
+    def get_channel_user_ini_path(channel: str) -> Path:
+        r"""Return ``{user_data_dir}\{channel}\user.ini`` for any channel.
+
+        Unlike :meth:`get_user_ini_path` this doesn't run the legacy
+        ``overrides.ini`` migration and doesn't depend on the *active*
+        channel — Export/Import Settings walks every channel, not just the
+        current one.
+        """
+        return AppSettings.get_user_data_dir() / channel / "user.ini"
+
+    @staticmethod
+    def export_channel_overrides() -> dict:
+        """Collect ``{channel: user.ini text}`` for every channel with one.
+
+        Reads ``user.ini`` (or the legacy ``overrides.ini`` when only that
+        exists) from each known channel dir. Empty files are skipped — no
+        point carrying zero-byte overrides in a backup.
+        """
+        overrides: dict = {}
+        for channel in AppSettings.AVAILABLE_CHANNELS:
+            path = AppSettings.get_channel_user_ini_path(channel)
+            if not path.exists():
+                legacy = path.parent / "overrides.ini"
+                if legacy.exists():
+                    path = legacy
+                else:
+                    continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError as e:
+                logger.warning(
+                    "Export Settings: could not read %s: %s", path, e
+                )
+                continue
+            if text.strip():
+                overrides[channel] = text
+        return overrides

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -417,7 +417,7 @@ class AppSettings:
         "base_global_path",
         "vehicles_path",
         "last_overrides_path",
-        "post_import/apply_pending",
+        POST_IMPORT_APPLY_PENDING,
     })
 
     # reconcile_imported_install_path() outcomes.

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -2887,8 +2887,6 @@ class AppSettings:
         a warning rather than poisoning the whole export — the known binary
         keys (window geometry/state) are already excluded by the filter.
         """
-        import json as _json
-
         backend = AppSettings.settings()
         if hasattr(backend, "allKeys"):
             keys = list(backend.allKeys())
@@ -2901,7 +2899,7 @@ class AppSettings:
             if AppSettings.is_profile_excluded_key(key, value):
                 continue
             try:
-                _json.dumps(value)
+                json.dumps(value)
             except (TypeError, ValueError):
                 logger.warning(
                     "Export Settings: skipping non-serialisable value for key "

--- a/src/utils/settings_profile.py
+++ b/src/utils/settings_profile.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import zipfile
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -221,9 +222,19 @@ def read_profile_zip(zip_path) -> ProfileContents:
             if not name.startswith(prefix) or not name.endswith("/user.ini"):
                 continue
             channel = name[len(prefix):-len("/user.ini")]
-            # Only accept a single, non-empty path segment as the channel
-            # (guards against a maliciously nested zip entry).
-            if not channel or "/" in channel:
+            # Only accept a single, non-empty, non-traversal path segment as
+            # the channel. A zip is untrusted input; a channel of ".."  or
+            # a backslash segment would otherwise let write_channel_user_ini
+            # (called by the importer with this value) land outside the
+            # data root on Windows, since only "/" was ever rejected here.
+            if (
+                not channel
+                or channel in (".", "..")
+                or "/" in channel
+                or "\\" in channel
+                or os.sep in channel
+                or (os.altsep and os.altsep in channel)
+            ):
                 continue
             try:
                 overrides[channel] = zf.read(name).decode("utf-8")

--- a/src/utils/settings_profile.py
+++ b/src/utils/settings_profile.py
@@ -1,0 +1,240 @@
+"""Package a user's Smart Citizen settings into a portable backup zip.
+
+The **Export Settings / Import Settings** feature (Config tab) lets a user
+snapshot everything that makes their install *theirs* — preferences plus
+per-channel ``user.ini`` string overrides — into one small ``.zip`` they can
+stash, move to a new PC, or restore after a fresh (portable) unzip. The pain
+it solves: portable updates land in a fresh versioned folder with an empty
+``data/``, so without this a user re-does all their settings every release.
+
+**What's in the zip** (and what's deliberately not):
+
+  SmartCitizen-Settings-Backup-{version}-{YYYYMMDD}.zip
+  ├── manifest.json          # schema + app version + when + source mode + channels
+  ├── settings.json          # every backend key/value, machine-specific keys stripped
+  └── overrides/
+      ├── LIVE/user.ini       # the user's own string overrides, per channel
+      └── PTU/user.ini
+
+  Excluded on purpose:
+    - the DataForge / base.ini **cache** (tens of MB, regenerates from the game)
+    - **backups/** (historical safety-nets, not part of the current settings)
+    - machine-specific settings (SC install path, data-dir / cache overrides,
+      window geometry) — those must re-detect or stay local on the target PC.
+      The exclusion of *settings* keys is the caller's job (it hands us an
+      already-filtered dict via ``AppSettings.export_all_values``); this module
+      only ever writes what it's given.
+
+This module owns the zip I/O and is deliberately **Qt-free and
+settings-free** (takes plain dicts + strings, returns plain data), so the
+pack/unpack contract is unit-testable without a QApplication or a real
+registry — same split as ``locpack_exporter.py``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import zipfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Bump when the on-disk layout changes in a way older readers can't handle.
+# read_profile_zip refuses a zip whose schema is newer than this so a backup
+# made by a future version doesn't get half-restored by an old one.
+SCHEMA_VERSION = 1
+
+MANIFEST_NAME = "manifest.json"
+SETTINGS_NAME = "settings.json"
+OVERRIDES_DIR = "overrides"
+
+SOURCE_MODE_PORTABLE = "portable"
+SOURCE_MODE_REGISTRY = "registry"
+
+
+class InvalidProfileError(ValueError):
+    """Raised when a file isn't a readable Smart Citizen settings backup.
+
+    Covers: not a zip, missing/garbled manifest, wrong app marker, or a
+    schema newer than this build understands. Callers surface a friendly
+    "that's not a Smart Citizen backup" message rather than crashing.
+    """
+
+
+@dataclass
+class ProfileContents:
+    """Everything read back out of a settings backup zip.
+
+    ``settings`` is the raw key/value dict (the caller decides which keys to
+    actually apply — see ``AppSettings.import_values``). ``overrides`` maps a
+    channel name (e.g. ``"LIVE"``) to that channel's ``user.ini`` text.
+    """
+
+    settings: dict[str, Any] = field(default_factory=dict)
+    overrides: dict[str, str] = field(default_factory=dict)
+    schema_version: int = SCHEMA_VERSION
+    app_version: str = ""
+    exported_at: str = ""
+    source_mode: str = ""
+
+
+def default_backup_filename(today: Optional[datetime] = None) -> str:
+    """Return a sensible default filename for the export dialog.
+
+    Format: ``SmartCitizen-Settings-Backup-{YYYYMMDD}.zip``. The word
+    "Backup" (not "Setup") keeps it from being mistaken for an installer,
+    and the date lets a user who keeps several snapshots tell them apart.
+
+    Deliberately **no version number**: backups are portable across app
+    versions (import only refuses a *newer* ``SCHEMA_VERSION`` than the
+    running build understands — see :func:`read_profile_zip`), and stamping
+    a version on the filename wrongly implies it's tied to that release.
+    The exporting version is still recorded in the manifest and shown in
+    the import confirmation.
+    """
+    when = today or datetime.now()
+    return f"SmartCitizen-Settings-Backup-{when.strftime('%Y%m%d')}.zip"
+
+
+def write_profile_zip(
+    output_zip_path,
+    *,
+    settings: dict[str, Any],
+    overrides: dict[str, str],
+    app_version: str,
+    source_mode: str,
+    now: Optional[datetime] = None,
+) -> int:
+    """Write a settings backup zip. Returns the number of entries written.
+
+    Args:
+        output_zip_path: Destination path (parent must exist — the
+            QFileDialog enforces this in the GUI path).
+        settings: Key/value dict to store as ``settings.json``. The caller is
+            responsible for having already stripped machine-specific keys.
+        overrides: ``{channel: user.ini text}``. Empty/missing channels are
+            simply absent — no placeholder files.
+        app_version: The exporting build's version, recorded in the manifest.
+        source_mode: ``"portable"`` or ``"registry"`` — informational; import
+            works regardless of which mode produced the zip (the settings keys
+            are identical across modes).
+        now: Injectable timestamp for deterministic tests.
+
+    Raises:
+        OSError: any I/O failure during the write.
+    """
+    when = now or datetime.now()
+    manifest = {
+        "app": "SmartCitizen",
+        "kind": "settings-backup",
+        "schema_version": SCHEMA_VERSION,
+        "app_version": app_version,
+        "exported_at": when.isoformat(timespec="seconds"),
+        "source_mode": source_mode,
+        "channels": sorted(overrides.keys()),
+    }
+
+    entries = 0
+    # ZIP_DEFLATED: the payload is a few KB of JSON/INI text and compresses
+    # heavily. compresslevel=9 is free at this size and the user runs it on
+    # demand.
+    with zipfile.ZipFile(
+        output_zip_path, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=9
+    ) as zf:
+        zf.writestr(MANIFEST_NAME, json.dumps(manifest, indent=2, sort_keys=True))
+        entries += 1
+        zf.writestr(
+            SETTINGS_NAME,
+            json.dumps(settings, indent=2, sort_keys=True, ensure_ascii=False),
+        )
+        entries += 1
+        for channel, text in sorted(overrides.items()):
+            # Forward slash inside the zip regardless of host OS (zip spec).
+            zf.writestr(f"{OVERRIDES_DIR}/{channel}/user.ini", text)
+            entries += 1
+
+    logger.info(
+        "Wrote settings backup: %s (%d entries, %d settings, %d channel overrides)",
+        output_zip_path, entries, len(settings), len(overrides),
+    )
+    return entries
+
+
+def read_profile_zip(zip_path) -> ProfileContents:
+    """Read + validate a settings backup zip into a :class:`ProfileContents`.
+
+    Raises:
+        InvalidProfileError: not a zip, missing/garbled manifest, not a Smart
+            Citizen settings backup, or a schema newer than this build supports.
+    """
+    try:
+        zf = zipfile.ZipFile(zip_path, mode="r")
+    except (zipfile.BadZipFile, OSError) as e:
+        raise InvalidProfileError(f"Not a readable zip file: {e}") from e
+
+    with zf:
+        names = set(zf.namelist())
+        if MANIFEST_NAME not in names:
+            raise InvalidProfileError(
+                "This zip has no manifest — it isn't a Smart Citizen settings backup."
+            )
+        try:
+            manifest = json.loads(zf.read(MANIFEST_NAME).decode("utf-8"))
+        except (ValueError, UnicodeDecodeError) as e:
+            raise InvalidProfileError(f"Backup manifest is unreadable: {e}") from e
+
+        if not isinstance(manifest, dict) or manifest.get("app") != "SmartCitizen":
+            raise InvalidProfileError(
+                "This backup wasn't made by Smart Citizen."
+            )
+
+        schema = manifest.get("schema_version")
+        if not isinstance(schema, int):
+            raise InvalidProfileError("Backup manifest is missing a schema version.")
+        if schema > SCHEMA_VERSION:
+            raise InvalidProfileError(
+                f"This backup was made by a newer version of Smart Citizen "
+                f"(backup schema {schema}, this build supports {SCHEMA_VERSION}). "
+                f"Update Smart Citizen, then import again."
+            )
+
+        # settings.json — tolerate absence (empty settings) but not corruption.
+        settings: dict[str, Any] = {}
+        if SETTINGS_NAME in names:
+            try:
+                loaded = json.loads(zf.read(SETTINGS_NAME).decode("utf-8"))
+            except (ValueError, UnicodeDecodeError) as e:
+                raise InvalidProfileError(f"Backup settings are unreadable: {e}") from e
+            if isinstance(loaded, dict):
+                settings = loaded
+            else:
+                raise InvalidProfileError(
+                    "Backup settings.json is not a JSON object."
+                )
+
+        # overrides/{channel}/user.ini — read each channel's text.
+        overrides: dict[str, str] = {}
+        prefix = f"{OVERRIDES_DIR}/"
+        for name in names:
+            if not name.startswith(prefix) or not name.endswith("/user.ini"):
+                continue
+            channel = name[len(prefix):-len("/user.ini")]
+            # Only accept a single, non-empty path segment as the channel
+            # (guards against a maliciously nested zip entry).
+            if not channel or "/" in channel:
+                continue
+            try:
+                overrides[channel] = zf.read(name).decode("utf-8")
+            except (UnicodeDecodeError, OSError) as e:
+                logger.warning("Skipping unreadable override %s: %s", name, e)
+
+    return ProfileContents(
+        settings=settings,
+        overrides=overrides,
+        schema_version=schema,
+        app_version=str(manifest.get("app_version") or ""),
+        exported_at=str(manifest.get("exported_at") or ""),
+        source_mode=str(manifest.get("source_mode") or ""),
+    )

--- a/tests/test_settings_profile.py
+++ b/tests/test_settings_profile.py
@@ -188,6 +188,29 @@ class TestValidation:
         p = read_profile_zip(out)
         assert p.overrides == {"LIVE": "good=1\n"}
 
+    def test_dot_dot_channel_segment_rejected(self, tmp_path):
+        """A bare ".." channel segment has no "/" to trip the old guard, but
+        would resolve get_channel_user_ini_path() outside the data root."""
+        out = tmp_path / "x.zip"
+        with zipfile.ZipFile(out, "w") as zf:
+            zf.writestr(MANIFEST_NAME, json.dumps({"app": "SmartCitizen", "schema_version": 1}))
+            zf.writestr("overrides/../user.ini", "evil=1\n")
+            zf.writestr("overrides/./user.ini", "evil=1\n")
+            zf.writestr("overrides/LIVE/user.ini", "good=1\n")
+        p = read_profile_zip(out)
+        assert p.overrides == {"LIVE": "good=1\n"}
+
+    def test_backslash_channel_segment_rejected(self, tmp_path):
+        """A backslash segment has no forward slash either, but is a real
+        path separator on Windows, where get_channel_user_ini_path() runs."""
+        out = tmp_path / "x.zip"
+        with zipfile.ZipFile(out, "w") as zf:
+            zf.writestr(MANIFEST_NAME, json.dumps({"app": "SmartCitizen", "schema_version": 1}))
+            zf.writestr("overrides/..\\evil/user.ini", "evil=1\n")
+            zf.writestr("overrides/LIVE/user.ini", "good=1\n")
+        p = read_profile_zip(out)
+        assert p.overrides == {"LIVE": "good=1\n"}
+
 
 class TestDefaultFilename:
     def test_format(self):

--- a/tests/test_settings_profile.py
+++ b/tests/test_settings_profile.py
@@ -1,0 +1,512 @@
+"""Export/Import Settings backup (settings_profile.py + AppSettings helpers).
+
+Covers the zip pack/unpack contract (manifest validation, per-channel
+overrides, schema forward-compat refusal) and the AppSettings side: the
+machine-specific key filter that runs on both export and import, backend
+enumeration for either backend shape, the post-import apply flag, and the
+per-channel user.ini collection. Ends with the full round-trip: export from
+one profile, import into a fresh one.
+"""
+import json
+import zipfile
+from datetime import datetime
+
+import pytest
+
+from src.utils.json_settings import JsonSettings
+from src.utils.settings import AppSettings
+from src.utils.settings_profile import (
+    InvalidProfileError,
+    MANIFEST_NAME,
+    SCHEMA_VERSION,
+    SETTINGS_NAME,
+    SOURCE_MODE_PORTABLE,
+    SOURCE_MODE_REGISTRY,
+    default_backup_filename,
+    read_profile_zip,
+    write_profile_zip,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def json_backend(tmp_path, monkeypatch):
+    """Swap AppSettings._backend for a tmp JsonSettings so each test is hermetic."""
+    saved = AppSettings._backend
+    AppSettings._backend = JsonSettings(tmp_path / "config.json")
+    yield AppSettings._backend
+    AppSettings._backend = saved
+
+
+@pytest.fixture
+def data_root(tmp_path, json_backend):
+    """Point the user-data dir at a tmp folder (via the override key)."""
+    root = tmp_path / "userdata"
+    root.mkdir()
+    json_backend.setValue(AppSettings.USER_DATA_DIR, str(root))
+    return root
+
+
+SETTINGS = {
+    "theme": "dark",
+    "favorite_prefix": "*",
+    "enhancements/categories/ships/enabled": True,
+    "tag_builder/components/config": '{"separator": "dash"}',
+}
+OVERRIDES = {
+    "LIVE": "vehicle_Name=Test Ship\n",
+    "PTU": "item_Name=Test Item\n",
+}
+
+
+def _write(tmp_path, **kwargs):
+    out = tmp_path / "backup.zip"
+    defaults = dict(
+        settings=SETTINGS,
+        overrides=OVERRIDES,
+        app_version="2.3.0",
+        source_mode=SOURCE_MODE_PORTABLE,
+    )
+    defaults.update(kwargs)
+    write_profile_zip(out, **defaults)
+    return out
+
+
+class TestWriteRead:
+    def test_round_trip(self, tmp_path):
+        out = _write(tmp_path)
+        p = read_profile_zip(out)
+        assert p.settings == SETTINGS
+        assert p.overrides == OVERRIDES
+        assert p.schema_version == SCHEMA_VERSION
+        assert p.app_version == "2.3.0"
+        assert p.source_mode == SOURCE_MODE_PORTABLE
+        assert p.exported_at  # ISO string recorded
+
+    def test_entry_count_and_layout(self, tmp_path):
+        out = _write(tmp_path)
+        with zipfile.ZipFile(out) as zf:
+            names = set(zf.namelist())
+        assert names == {
+            MANIFEST_NAME,
+            SETTINGS_NAME,
+            "overrides/LIVE/user.ini",
+            "overrides/PTU/user.ini",
+        }
+
+    def test_no_overrides_is_fine(self, tmp_path):
+        out = _write(tmp_path, overrides={})
+        p = read_profile_zip(out)
+        assert p.overrides == {}
+        assert p.settings == SETTINGS
+
+    def test_registry_source_mode_round_trips(self, tmp_path):
+        out = _write(tmp_path, source_mode=SOURCE_MODE_REGISTRY)
+        assert read_profile_zip(out).source_mode == SOURCE_MODE_REGISTRY
+
+    def test_manifest_channels_listed(self, tmp_path):
+        out = _write(tmp_path)
+        with zipfile.ZipFile(out) as zf:
+            manifest = json.loads(zf.read(MANIFEST_NAME))
+        assert manifest["channels"] == ["LIVE", "PTU"]
+        assert manifest["app"] == "SmartCitizen"
+
+    def test_unicode_survives(self, tmp_path):
+        out = _write(
+            tmp_path,
+            settings={"favorite_prefix": "★"},
+            overrides={"LIVE": "vehicle_Name=Ærøskøbing — ✓\n"},
+        )
+        p = read_profile_zip(out)
+        assert p.settings["favorite_prefix"] == "★"
+        assert "Ærøskøbing — ✓" in p.overrides["LIVE"]
+
+
+class TestValidation:
+    def test_not_a_zip(self, tmp_path):
+        bad = tmp_path / "not.zip"
+        bad.write_text("this is not a zip")
+        with pytest.raises(InvalidProfileError):
+            read_profile_zip(bad)
+
+    def test_zip_without_manifest(self, tmp_path):
+        out = tmp_path / "x.zip"
+        with zipfile.ZipFile(out, "w") as zf:
+            zf.writestr("random.txt", "hello")
+        with pytest.raises(InvalidProfileError, match="manifest"):
+            read_profile_zip(out)
+
+    def test_wrong_app_marker(self, tmp_path):
+        out = tmp_path / "x.zip"
+        with zipfile.ZipFile(out, "w") as zf:
+            zf.writestr(MANIFEST_NAME, json.dumps({"app": "SomethingElse", "schema_version": 1}))
+        with pytest.raises(InvalidProfileError, match="wasn't made by"):
+            read_profile_zip(out)
+
+    def test_newer_schema_refused(self, tmp_path):
+        out = tmp_path / "x.zip"
+        with zipfile.ZipFile(out, "w") as zf:
+            zf.writestr(
+                MANIFEST_NAME,
+                json.dumps({"app": "SmartCitizen", "schema_version": SCHEMA_VERSION + 1}),
+            )
+        with pytest.raises(InvalidProfileError, match="newer version"):
+            read_profile_zip(out)
+
+    def test_garbled_manifest(self, tmp_path):
+        out = tmp_path / "x.zip"
+        with zipfile.ZipFile(out, "w") as zf:
+            zf.writestr(MANIFEST_NAME, "{not json")
+        with pytest.raises(InvalidProfileError):
+            read_profile_zip(out)
+
+    def test_garbled_settings(self, tmp_path):
+        out = tmp_path / "x.zip"
+        with zipfile.ZipFile(out, "w") as zf:
+            zf.writestr(MANIFEST_NAME, json.dumps({"app": "SmartCitizen", "schema_version": 1}))
+            zf.writestr(SETTINGS_NAME, "[1, 2")
+        with pytest.raises(InvalidProfileError):
+            read_profile_zip(out)
+
+    def test_settings_must_be_object(self, tmp_path):
+        out = tmp_path / "x.zip"
+        with zipfile.ZipFile(out, "w") as zf:
+            zf.writestr(MANIFEST_NAME, json.dumps({"app": "SmartCitizen", "schema_version": 1}))
+            zf.writestr(SETTINGS_NAME, json.dumps([1, 2, 3]))
+        with pytest.raises(InvalidProfileError, match="JSON object"):
+            read_profile_zip(out)
+
+    def test_nested_override_entry_skipped(self, tmp_path):
+        """A crafted zip can't smuggle an override outside a channel dir."""
+        out = tmp_path / "x.zip"
+        with zipfile.ZipFile(out, "w") as zf:
+            zf.writestr(MANIFEST_NAME, json.dumps({"app": "SmartCitizen", "schema_version": 1}))
+            zf.writestr("overrides/LIVE/../evil/user.ini", "x=y\n")
+            zf.writestr("overrides/LIVE/nested/user.ini", "x=y\n")
+            zf.writestr("overrides/LIVE/user.ini", "good=1\n")
+        p = read_profile_zip(out)
+        assert p.overrides == {"LIVE": "good=1\n"}
+
+
+class TestDefaultFilename:
+    def test_format(self):
+        name = default_backup_filename(today=datetime(2026, 7, 24))
+        assert name == "SmartCitizen-Settings-Backup-20260724.zip"
+
+    def test_no_version_in_name(self):
+        """Backups import across app versions; the name must not imply otherwise."""
+        assert "2.3.0" not in default_backup_filename(today=datetime(2026, 7, 24))
+
+
+class TestExcludedKeys:
+    @pytest.mark.parametrize("key", sorted(AppSettings.PROFILE_EXCLUDE_KEYS))
+    def test_explicit_exclusions(self, key):
+        assert AppSettings.is_profile_excluded_key(key)
+
+    def test_migration_markers_excluded(self):
+        assert AppSettings.is_profile_excluded_key("_channel_layout_migrated")
+        assert AppSettings.is_profile_excluded_key("_retired_url_sources_pruned_v3")
+
+    def test_local_source_path_excluded_url_kept(self):
+        key = "data_sources/global/path"
+        assert AppSettings.is_profile_excluded_key(key, r"C:\Users\x\Documents\base.ini")
+        assert not AppSettings.is_profile_excluded_key(key, "https://example.com/global.ini")
+
+    def test_ordinary_keys_travel(self):
+        assert not AppSettings.is_profile_excluded_key("theme", "dark")
+        assert not AppSettings.is_profile_excluded_key("merge_hierarchy", ["global", "user"])
+        assert not AppSettings.is_profile_excluded_key("data_sources/global/enabled", True)
+
+
+class TestExportAllValues:
+    def test_filters_machine_keys(self, json_backend):
+        json_backend.setValue("theme", "dark")
+        json_backend.setValue(AppSettings.USER_DATA_DIR, r"C:\Users\x\Documents\SC")
+        json_backend.setValue(AppSettings.CACHE_DIR, r"D:\dataforge-cache")
+        json_backend.setValue("_channel_layout_migrated", True)
+        out = AppSettings.export_all_values()
+        assert out == {"theme": "dark"}
+
+    def test_sc_install_path_travels(self, json_backend):
+        """The game folder IS carried — reconcile validates it on import."""
+        json_backend.setValue(AppSettings.SC_INSTALL_ROOT, r"C:\Games\StarCitizen")
+        out = AppSettings.export_all_values()
+        assert out[AppSettings.SC_INSTALL_ROOT] == r"C:\Games\StarCitizen"
+
+    def test_non_serialisable_value_skipped(self, json_backend):
+        json_backend.setValue("theme", "dark")
+        # Bypass _persist's own guard by poking the in-memory dict — mimics a
+        # backend whose value() hands back a non-JSON type (QSettings can).
+        json_backend._data["weird"] = object()
+        out = AppSettings.export_all_values()
+        assert "weird" not in out
+        assert out["theme"] == "dark"
+
+    def test_allkeys_backend_shape(self, monkeypatch):
+        """QSettings-shaped backends (allKeys, not keys) enumerate fine."""
+        class FakeQSettings:
+            def __init__(self):
+                self._d = {"theme": "light", "user_data_dir": r"C:\x"}
+            def allKeys(self):
+                return list(self._d)
+            def value(self, key, default=None, type=None):  # noqa: A002
+                return self._d.get(key, default)
+        saved = AppSettings._backend
+        AppSettings._backend = FakeQSettings()
+        try:
+            out = AppSettings.export_all_values()
+        finally:
+            AppSettings._backend = saved
+        assert out == {"theme": "light"}
+
+
+class TestImportValues:
+    def test_applies_and_filters(self, json_backend):
+        applied = AppSettings.import_values({
+            "theme": "dark",
+            "favorite_prefix": "*",
+            AppSettings.USER_DATA_DIR: r"D:\Old\PC\Documents",
+            "_channel_layout_migrated": True,
+        })
+        assert applied == 2
+        assert json_backend.value("theme") == "dark"
+        assert json_backend.value(AppSettings.USER_DATA_DIR) is None
+        assert json_backend.value("_channel_layout_migrated") is None
+
+    def test_layers_over_existing(self, json_backend):
+        json_backend.setValue("theme", "light")
+        json_backend.setValue("favorite_prefix", "*")
+        AppSettings.import_values({"theme": "dark"})
+        assert json_backend.value("theme") == "dark"
+        assert json_backend.value("favorite_prefix") == "*"  # untouched
+
+    def test_non_string_keys_ignored(self, json_backend):
+        assert AppSettings.import_values({3: "x", "": "y", "ok": 1}) == 1
+
+
+class TestPostImportFlag:
+    def test_default_false(self, json_backend):
+        assert AppSettings.get_post_import_apply_pending() is False
+
+    def test_set_and_clear(self, json_backend):
+        AppSettings.set_post_import_apply_pending(True)
+        assert AppSettings.get_post_import_apply_pending() is True
+        AppSettings.set_post_import_apply_pending(False)
+        assert AppSettings.get_post_import_apply_pending() is False
+        # Cleared = removed, not stored False — the key never lingers.
+        assert AppSettings.POST_IMPORT_APPLY_PENDING not in json_backend.keys()
+
+    def test_flag_never_travels_in_backup(self, json_backend):
+        AppSettings.set_post_import_apply_pending(True)
+        assert AppSettings.POST_IMPORT_APPLY_PENDING not in AppSettings.export_all_values()
+
+
+class TestExportChannelOverrides:
+    def test_collects_per_channel(self, data_root):
+        (data_root / "LIVE").mkdir()
+        (data_root / "LIVE" / "user.ini").write_text("a=1\n", encoding="utf-8")
+        (data_root / "PTU").mkdir()
+        (data_root / "PTU" / "user.ini").write_text("b=2\n", encoding="utf-8")
+        assert AppSettings.export_channel_overrides() == {"LIVE": "a=1\n", "PTU": "b=2\n"}
+
+    def test_empty_and_missing_skipped(self, data_root):
+        (data_root / "LIVE").mkdir()
+        (data_root / "LIVE" / "user.ini").write_text("", encoding="utf-8")
+        assert AppSettings.export_channel_overrides() == {}
+
+    def test_legacy_overrides_ini_fallback(self, data_root):
+        (data_root / "EPTU").mkdir()
+        (data_root / "EPTU" / "overrides.ini").write_text("c=3\n", encoding="utf-8")
+        assert AppSettings.export_channel_overrides() == {"EPTU": "c=3\n"}
+
+
+class TestReconcileInstallPath:
+    """The imported SC folder is kept only when it exists on this machine."""
+
+    @staticmethod
+    def _make_sc_root(tmp_path, name="StarCitizen"):
+        root = tmp_path / name
+        (root / "LIVE").mkdir(parents=True)
+        return root
+
+    def test_valid_path_restored(self, tmp_path, json_backend):
+        root = self._make_sc_root(tmp_path)
+        json_backend.setValue(AppSettings.SC_INSTALL_ROOT, str(root))
+        assert (
+            AppSettings.reconcile_imported_install_path()
+            == AppSettings.INSTALL_PATH_RESTORED
+        )
+        assert AppSettings.get_sc_install_root() == str(root)
+
+    def test_restore_syncs_legacy_game_path(self, tmp_path, json_backend):
+        root = self._make_sc_root(tmp_path)
+        json_backend.setValue(AppSettings.SC_INSTALL_ROOT, str(root))
+        AppSettings.reconcile_imported_install_path()
+        # game_install_path must be re-derived, not left stale from the backup.
+        assert json_backend.value(AppSettings.GAME_INSTALL_PATH) == str(
+            root / AppSettings.get_active_channel()
+        )
+
+    def test_dead_path_cleared(self, tmp_path, json_backend, monkeypatch):
+        json_backend.setValue(AppSettings.SC_INSTALL_ROOT, str(tmp_path / "nope"))
+        json_backend.setValue(AppSettings.GAME_INSTALL_PATH, str(tmp_path / "nope" / "LIVE"))
+        # Neutralise the real detection chain so this stays hermetic.
+        monkeypatch.setattr(AppSettings, "get_sc_install_root", staticmethod(lambda: ""))
+        assert (
+            AppSettings.reconcile_imported_install_path()
+            == AppSettings.INSTALL_PATH_NONE
+        )
+        assert json_backend.value(AppSettings.SC_INSTALL_ROOT) is None
+        assert json_backend.value(AppSettings.GAME_INSTALL_PATH) is None
+
+    def test_dead_path_falls_back_to_detection(self, tmp_path, json_backend, monkeypatch):
+        other = self._make_sc_root(tmp_path, "DetectedElsewhere")
+        json_backend.setValue(AppSettings.SC_INSTALL_ROOT, str(tmp_path / "nope"))
+        monkeypatch.setattr(
+            AppSettings, "get_sc_install_root", staticmethod(lambda: str(other))
+        )
+        assert (
+            AppSettings.reconcile_imported_install_path()
+            == AppSettings.INSTALL_PATH_REDETECTED
+        )
+
+    def test_no_path_in_backup(self, json_backend, monkeypatch):
+        monkeypatch.setattr(AppSettings, "get_sc_install_root", staticmethod(lambda: ""))
+        assert (
+            AppSettings.reconcile_imported_install_path()
+            == AppSettings.INSTALL_PATH_NONE
+        )
+
+    def test_a_file_is_not_a_valid_root(self, tmp_path, json_backend, monkeypatch):
+        bogus = tmp_path / "StarCitizen.txt"
+        bogus.write_text("not a folder")
+        json_backend.setValue(AppSettings.SC_INSTALL_ROOT, str(bogus))
+        monkeypatch.setattr(AppSettings, "get_sc_install_root", staticmethod(lambda: ""))
+        assert (
+            AppSettings.reconcile_imported_install_path()
+            == AppSettings.INSTALL_PATH_NONE
+        )
+
+    def test_dir_without_channel_folder_rejected(self, tmp_path, json_backend, monkeypatch):
+        empty = tmp_path / "EmptyDir"
+        empty.mkdir()
+        json_backend.setValue(AppSettings.SC_INSTALL_ROOT, str(empty))
+        monkeypatch.setattr(AppSettings, "get_sc_install_root", staticmethod(lambda: ""))
+        assert (
+            AppSettings.reconcile_imported_install_path()
+            == AppSettings.INSTALL_PATH_NONE
+        )
+
+
+class TestFullRoundTrip:
+    def test_export_import_across_profiles(self, tmp_path, data_root, json_backend):
+        # Profile A: preferences + the game folder + a LIVE override.
+        sc_root = tmp_path / "StarCitizen"
+        (sc_root / "LIVE").mkdir(parents=True)
+        json_backend.setValue("theme", "dark")
+        json_backend.setValue("tag_builder/components/config", '{"separator": "dash"}')
+        json_backend.setValue(AppSettings.SC_INSTALL_ROOT, str(sc_root))
+        json_backend.setValue(AppSettings.USER_DATA_DIR, str(data_root))
+        (data_root / "LIVE").mkdir()
+        (data_root / "LIVE" / "user.ini").write_text("vehicle_Name=X\n", encoding="utf-8")
+
+        out = tmp_path / "roundtrip.zip"
+        write_profile_zip(
+            out,
+            settings=AppSettings.export_all_values(),
+            overrides=AppSettings.export_channel_overrides(),
+            app_version="2.3.0",
+            source_mode=SOURCE_MODE_REGISTRY,
+        )
+
+        # Profile B: a fresh backend, import the zip.
+        AppSettings._backend = JsonSettings(tmp_path / "fresh-config.json")
+        profile = read_profile_zip(out)
+        applied = AppSettings.import_values(profile.settings)
+
+        assert applied == 3
+        assert AppSettings.settings().value("theme") == "dark"
+        assert AppSettings.settings().value("tag_builder/components/config") == '{"separator": "dash"}'
+        # The game folder DID follow the backup, and still exists here.
+        assert AppSettings.settings().value(AppSettings.SC_INSTALL_ROOT) == str(sc_root)
+        assert (
+            AppSettings.reconcile_imported_install_path()
+            == AppSettings.INSTALL_PATH_RESTORED
+        )
+        # The data-root override did NOT follow (machine-local).
+        assert AppSettings.settings().value(AppSettings.USER_DATA_DIR) is None
+        assert profile.overrides == {"LIVE": "vehicle_Name=X\n"}
+
+    def test_backup_imports_into_a_different_app_version(self, tmp_path, json_backend):
+        """A backup made by an older build imports into a newer one."""
+        out = tmp_path / "old.zip"
+        write_profile_zip(
+            out,
+            settings={"theme": "dark"},
+            overrides={},
+            app_version="2.2.0",           # exported by an older release
+            source_mode=SOURCE_MODE_REGISTRY,
+        )
+        profile = read_profile_zip(out)    # running build reads it fine
+        assert profile.app_version == "2.2.0"
+        assert AppSettings.import_values(profile.settings) == 1
+
+
+class TestExportFlushesTagBuilder:
+    """Export must back up the Tag Builder state the user is *looking at*.
+
+    Tag configs only reach settings via Save Tag Changes / Generate
+    Enhancements (`_persist_tag_builder_state`), so exporting without
+    flushing would snapshot the previous config — the same trap #215 fixed
+    for Generate. Driven on a lightweight stand-in ``self`` with the real
+    unbound method, matching tests/test_ui_mode.py (no pytest-qt in dev
+    deps — see tests/CLAUDE.md).
+    """
+
+    def test_export_flushes_pending_tag_edits_before_reading(self, tmp_path, json_backend):
+        from src.gui.main_window import MainWindow
+
+        calls = []
+
+        class FakeTab:
+            def flush_pending_tag_edits(self):
+                # Mimic the real flush landing the on-screen config.
+                calls.append("flushed")
+                AppSettings.settings().setValue(
+                    "tag_builder/components/config", '{"separator": "underscore"}'
+                )
+
+        class FakeStatusBar:
+            def showMessage(self, *a, **k):
+                pass
+
+        captured = {}
+
+        class Stub:
+            enhancements_tab = FakeTab()
+
+            def statusBar(self):
+                return FakeStatusBar()
+
+        stub = Stub()
+
+        # Cancel at the file dialog: we only care that the flush already
+        # happened by the time values are read.
+        import src.gui.main_window as mw
+
+        def fake_save_dialog(*a, **k):
+            captured["at_dialog"] = AppSettings.export_all_values()
+            return ("", "")
+
+        orig = mw.QFileDialog.getSaveFileName
+        mw.QFileDialog.getSaveFileName = staticmethod(fake_save_dialog)
+        try:
+            MainWindow._handle_export_settings(stub)
+        finally:
+            mw.QFileDialog.getSaveFileName = orig
+
+        assert calls == ["flushed"], "export must flush Tag Builder edits first"
+        assert captured["at_dialog"].get("tag_builder/components/config") == (
+            '{"separator": "underscore"}'
+        ), "the flushed on-screen tag config must be in the exported values"

--- a/tests/test_tag_builder_import_refresh.py
+++ b/tests/test_tag_builder_import_refresh.py
@@ -1,0 +1,137 @@
+"""Imported Tag Builder configs must survive a later widget-driven save.
+
+Regression for the Export/Import Settings feature: `_tag_builder_pages` is
+built once at tab construction, so an import that rewrites the
+`tag_builder/*` keys underneath a live tab leaves the pages holding the
+PRE-import config. The next `_persist_tag_builder_state()` — reachable from
+Save Tag Changes, Generate Enhancements, and Export Settings — then wrote
+that stale state back over everything the import restored, which is how
+imported tag configs were being lost.
+
+`EnhancementsTab.reload_tag_builder_from_settings()` (called by
+`MainWindow._handle_import_settings`) resyncs the pages so none of those
+paths can resurrect the old config.
+
+Needs a real QApplication for the widgets, so it uses the offscreen Qt
+platform like tests/test_ui_mode.py rather than pytest-qt (not a dev dep).
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from src.utils.json_settings import JsonSettings  # noqa: E402
+from src.utils.settings import AppSettings  # noqa: E402
+from src.utils.tag_builder import CATEGORIES, default_config  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
+
+CUSTOM_SEPARATOR = "underscore"
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture
+def json_backend(tmp_path):
+    saved = AppSettings._backend
+    AppSettings._backend = JsonSettings(tmp_path / "config.json")
+    yield AppSettings._backend
+    AppSettings._backend = saved
+
+
+def _import_custom_configs():
+    """Mimic Import Settings writing a customised backup into settings."""
+    for cat in CATEGORIES:
+        cfg = default_config(cat)
+        cfg.separator = CUSTOM_SEPARATOR
+        AppSettings.set_tag_config(cat, cfg)
+    AppSettings.set_tag_annotate_mission_descs(False)
+
+
+def _separators() -> dict:
+    return {c: AppSettings.get_tag_config(c).separator for c in CATEGORIES}
+
+
+class TestImportRefresh:
+    def test_stale_pages_clobber_import_without_refresh(self, qapp, json_backend):
+        """Locks the failure mode itself, so a future refactor can't undo the fix."""
+        from src.gui.enhancements_tab import EnhancementsTab
+
+        tab = EnhancementsTab()                 # built against an empty profile
+        _import_custom_configs()                # import lands underneath it
+        tab._persist_tag_builder_state()        # Save / Generate / Export
+        assert all(v != CUSTOM_SEPARATOR for v in _separators().values()), (
+            "expected the un-refreshed page state to overwrite the import — "
+            "if this now passes, the clobber path changed and this test needs review"
+        )
+
+    def test_refresh_makes_import_survive_a_later_save(self, qapp, json_backend):
+        from src.gui.enhancements_tab import EnhancementsTab
+
+        tab = EnhancementsTab()
+        _import_custom_configs()
+        tab.reload_tag_builder_from_settings()  # the fix
+        tab._persist_tag_builder_state()
+        assert _separators() == {c: CUSTOM_SEPARATOR for c in CATEGORIES}
+
+    def test_refresh_updates_the_visible_pages(self, qapp, json_backend):
+        from src.gui.enhancements_tab import EnhancementsTab
+
+        tab = EnhancementsTab()
+        _import_custom_configs()
+        tab.reload_tag_builder_from_settings()
+        assert {c: p.config.separator for c, p in tab._tag_builder_pages.items()} == {
+            c: CUSTOM_SEPARATOR for c in CATEGORIES
+        }
+
+    def test_refresh_syncs_annotate_toggle(self, qapp, json_backend):
+        from src.gui.enhancements_tab import EnhancementsTab
+
+        tab = EnhancementsTab()
+        _import_custom_configs()                # imported it as False
+        tab.reload_tag_builder_from_settings()
+        assert tab._annotate_mission_descs_cb.isChecked() is False
+
+    def test_refresh_leaves_save_button_clean(self, qapp, json_backend):
+        """Nothing is unsaved after a refresh, so the button must not light up."""
+        from src.gui.enhancements_tab import EnhancementsTab
+
+        tab = EnhancementsTab()
+        _import_custom_configs()
+        tab.reload_tag_builder_from_settings()
+        assert tab._tag_dirty is False
+
+    def test_refresh_does_not_write_title_tags(self, qapp, json_backend):
+        """The import path mirrors General Tags; it must not persist over them."""
+        from src.gui.enhancements_tab import EnhancementsTab
+
+        tab = EnhancementsTab()
+        AppSettings.set_mission_title_tag("rep_track", True)  # non-default
+        _import_custom_configs()
+        tab.reload_tag_builder_from_settings()
+        assert AppSettings.get_mission_title_tags()["rep_track"] is True
+
+    def test_reset_to_defaults_still_persists_title_tags(self, qapp, json_backend):
+        """The refactor must not change Reset-to-defaults' write behaviour."""
+        from src.gui.enhancements_tab import EnhancementsTab
+
+        tab = EnhancementsTab()
+        AppSettings.set_mission_title_tag("rep_track", True)
+        tab._tag_builder_pages["mission_titles"]._reset_to_defaults()
+        assert AppSettings.get_mission_title_tags()["rep_track"] == (
+            AppSettings.get_mission_title_tag_default("rep_track")
+        )


### PR DESCRIPTION
## Why

Portable users re-do their whole setup on every update — each release unzips into a fresh versioned folder with an empty `data/`, stranding the previous one. This is also the "I got a new PC" path.

Adds a **Settings Backup** group to the Config tab: **Export Settings…** / **Import Settings…**, producing one small zip (a few KB in practice).

## What's in the backup

| Included | Excluded |
|---|---|
| Every backend setting (preferences, tag configs, category toggles) | DataForge / `base.ini` cache — tens of MB, rebuilds from the game |
| The Star Citizen install path | `backups/` |
| Each channel's `user.ini` | Data-root and cache-dir overrides |

The data-root/cache overrides are deliberately excluded: pointing them at a drive that doesn't exist on the target machine would strand every path derived from them. Measured on a real profile, the cache was 14 MB while the actual settings were under 1 KB.

## Cross-version by design

The zip carries a manifest (schema version, exporting app version, source mode, channels). A backup made by any build imports into any other; import only refuses a schema **newer** than the running build understands. The filename omits the app version so it doesn't imply otherwise — the exporting version is still recorded in the manifest and shown in the import confirmation.

## Import is validated, and reversible

1. Validates the zip (rejects non-backups, unreadable manifests, newer schemas) and shows what's inside before doing anything.
2. Snapshots current `user.ini` files into the channel's rotating backups (#172 machinery) — so an unwanted import is undoable via **Restore user.ini**.
3. Reconciles the Star Citizen path: **kept** when the folder actually exists here, **dropped in favour of auto-detection** when it doesn't — a backup from another machine can't pin the user to a dead path.
4. Sets a one-shot flag and offers a restart. The next launch offers to regenerate + apply enhancements, reusing the Simple-mode generate-then-apply continuation (#180).

Restart is required because most settings are read once into widgets at construction; there's no existing full-UI-rehydrate path (same limitation `i18n.py` documents for language switching).

## Two lifecycle details worth reviewing

- **Export flushes on-screen Tag Builder edits first**, so the backup captures what the user is looking at rather than the last-saved state — the same "what you see is what you save" rule Generate Enhancements follows (#215).
- **Import refreshes the Tag Builder pages and category checkboxes afterwards.** These widgets cache settings at construction, so an import that rewrote the `tag_builder/*` keys underneath a live tab left the pages holding the pre-import config — and the next Save Tag Changes / Generate / Export wrote that stale state straight back over the import. This was a real, reproduced bug found in testing. `_reset_to_defaults` is refactored into `apply_config()` so the refresh reuses the existing widget-resync logic rather than duplicating it; Reset keeps persisting General Tags defaults, the import path only mirrors them.

## Both build variants

Export/import go through the `AppSettings` backend abstraction, so this works identically in registry and portable builds — one zip format moves a setup between the installer and portable variants in either direction.

## Dependency note

Import calls `get_sc_install_root()`, so it inherits whatever detection that method offers. Full multi-drive auto-detection (#269) reaches this branch with the `release/2.2.1` merge in #289; until that lands, the fallback here is the two hardcoded Program Files paths. No code change needed either way — this picks it up automatically.

## Testing

- `tests/test_settings_profile.py` — round trip, manifest validation, machine-key filtering, install-path reconciliation, cross-version import, crafted-zip path traversal.
- `tests/test_tag_builder_import_refresh.py` — the import-refresh fix, including a test that locks the **failure mode itself** so a future refactor can't silently undo it.
- Full suite: **1238 passed, 0 failed**.
- Manually verified on a frozen portable build: customise → export → wipe `data/` → import → restart → settings, game folder, and Tag Builder config all restored; confirmed the previously-broken "Restart Later → Generate Enhancements" path no longer clobbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)