### PR TITLE
Fix unresolved merge conflict markers in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,7 @@ A Windows desktop app for customizing Star Citizen's localization strings. Layer
 ## Features
 
 - **Multi-Channel Star Citizen Support**: LIVE / PTU / EPTU / HOTFIX / TECH-PREVIEW each get their own isolated workspace — independent `user.ini`, cache, backups, DataForge extraction, and enhancement INIs. Switch channels from the Config tab without restarting.
-<<<<<<< HEAD
-- **Multi-Language Support**: Switch the app and game strings between English, French, Spanish, Brazilian Portuguese, and Italian from the Config tab. Non-English languages layer a community-translated `global.ini` (from [Dymerz/StarCitizen-Localization](https://github.com/Dymerz/StarCitizen-Localization)) over the English base, with English fallback for anything untranslated.
-=======
-- **Multi-Language Support**: Switch the app and game strings between English, French, Spanish, Brazilian Portuguese, and Chinese from the Config tab. Non-English languages layer a community-translated `global.ini` (from [Dymerz/StarCitizen-Localization](https://github.com/Dymerz/StarCitizen-Localization) and [42Kit](https://ini.42kit.com/)) over the English base, with English fallback for anything untranslated.
->>>>>>> origin/release/2.3.0
+- **Multi-Language Support**: Switch the app and game strings between English, French, Spanish, Brazilian Portuguese, Japanese, Chinese, and Italian from the Config tab. Non-English languages layer a community-translated `global.ini` (from [Dymerz/StarCitizen-Localization](https://github.com/Dymerz/StarCitizen-Localization), [42Kit](https://ini.42kit.com/), and [stdblue/StarCitizenJapaneseResources](https://github.com/stdblue/StarCitizenJapaneseResources)) over the English base, with English fallback for anything untranslated.
 - **Simple & Advanced Mode**: A two-button Simple screen (one applies enhancements with your saved settings, the other switches to Advanced), or the full Advanced UI (table, filters, Enhancements, Config) for hand-editing. Pick your default at install; switch anytime in-app.
 - **Multi-Source Merge System**: Sources (stock base, language overlay, enhancements, user) merge in a drag-and-drop priority order, with user overrides always applied last so your edits never get overwritten.
 - **Sourced from Data.p4k**: All stock localization and DataForge entity data is extracted directly from your installed game — no community mirrors, no version drift, no network required after install.
@@ -108,11 +104,7 @@ All settings are stored in Windows Registry under:
 The Config tab lets you set:
 - **Star Citizen install path** (the SC root folder containing `LIVE/`, `PTU/`, etc. — auto-detected at install time)
 - **Active channel** (LIVE / PTU / EPTU / HOTFIX / TECH-PREVIEW)
-<<<<<<< HEAD
-- **Language** (English, French, Spanish, Brazilian Portuguese, Italian; switches the app UI and the game strings)
-=======
-- **Language** (English, French, Spanish, Brazilian Portuguese, Chinese; switches the app UI and the game strings)
->>>>>>> origin/release/2.3.0
+- **Language** (English, French, Spanish, Brazilian Portuguese, Japanese, Chinese, Italian; switches the app UI and the game strings)
 - **Smart Citizen data folder** (where `user.ini`, cache, DataForge extraction, enhancement INIs, and backups live)
 - **Theme**
 - **Data sources**: enable/disable, drag-drop merge priority
@@ -224,11 +216,9 @@ Thanks to those who've contributed code to Smart Citizen:
 - **Akwa** — French interface translation
 - **Nxzzin** — Brazilian Portuguese interface translation
 - [**Thord82**](https://github.com/Thord82) — Spanish interface translation, plus the [Spanish `global.ini` source](https://github.com/Thord82/Star_citizen_ES) that powers the Spanish game strings
-<<<<<<< HEAD
-- The Italian interface translation is AI-generated pending a human reviewer; the Italian `global.ini` source is the same [Dymerz/StarCitizen-Localization](https://github.com/Dymerz/StarCitizen-Localization) repo credited below
-=======
+- [**stdblue/StarCitizenJapaneseResources**](https://github.com/stdblue/StarCitizenJapaneseResources) — the Japanese `global.ini` source that powers the Japanese game strings; the Japanese interface translation is AI-generated pending a human reviewer
 - [**42Kit**](https://ini.42kit.com/) — the [Chinese `global.ini` source](https://ini.42kit.com/full/global.ini) that powers the Chinese game strings; the Chinese interface translation is AI-generated pending a human reviewer
->>>>>>> origin/release/2.3.0
+- The Italian interface translation is AI-generated pending a human reviewer; the Italian `global.ini` source is the same [Dymerz/StarCitizen-Localization](https://github.com/Dymerz/StarCitizen-Localization) repo credited below
 - [**Osiris-DevWorks/odw-fast-unp4k**](https://github.com/Osiris-DevWorks/odw-fast-unp4k) — Bundled `unp4k.exe` / `unforge.exe` used to unpack `Data.p4k` and convert DataForge to XML; our parallelized fork of the original [dolkensp/unp4k](https://github.com/dolkensp/unp4k)
 - [**Dymerz/StarCitizen-Localization**](https://github.com/Dymerz/StarCitizen-Localization) — Community-maintained `global.ini` translations that power the non-English language options
 - [**ExoAE**](https://github.com/ExoAE/ScCompLangPack) — Original ScCompLangPack concept and merge logic that inspired Smart Citizen's foundation


### PR DESCRIPTION
The Italian language merge (#321) accidentally landed `README.md` on `release/2.3.0` with **unresolved conflict markers** (`<<<<<<<` / `=======` / `>>>>>>>`) in three places: the Multi-Language Support feature bullet, the Config-tab Language line, and the translation credits. Cause: during that merge the `README.md` conflict scrolled off the top of a truncated console view and wasn't resolved before commit.

This resolves all three to the correct union of every shipping language — English, French, Spanish, Brazilian Portuguese, Japanese, Chinese, Italian — and credits the Japanese (stdblue), Chinese (42Kit), and Italian (Dymerz) `global.ini` sources. `README.md` is now marker-free (verified). No other file on the branch is affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLr6xueNzde9dmwdfG4R7j)_