### PR TITLE
[#317] Add release/** to CI's pull_request trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,16 @@
 name: CI
 
-# Runs on every PR + every push to main / 1.3.0. Validates that the test
-# suite passes and that the PyInstaller onedir build succeeds. Inno Setup
-# installer compilation is deliberately scoped out of CI — that step lives
-# in release.yml because it adds ~3 minutes of toolchain install per run
-# and produces an artifact only useful at release time.
+# Runs on every PR targeting main / master / 1.3.0 / any release/* branch,
+# plus every push to 1.3.0. Validates that the test suite passes and that
+# the PyInstaller onedir build succeeds. Inno Setup installer compilation
+# is deliberately scoped out of CI — that step lives in release.yml
+# because it adds ~3 minutes of toolchain install per run and produces an
+# artifact only useful at release time.
+#
+# release/** was missing from the pull_request trigger until #317: every
+# PR targeting the active release/X.Y.Z branch ran with zero CI coverage,
+# which is how the 2.3.0 language PRs' post-merge key-coverage gap (#318)
+# went undetected until a full local integration merge caught it.
 #
 # Windows-only: Smart Citizen uses Windows Registry via PyQt6 QSettings, so
 # Linux/macOS runners can't import src/utils/settings.py. windows-latest is
@@ -20,7 +26,7 @@ on:
   push:
     branches: ["1.3.0"]
   pull_request:
-    branches: [main, master, "1.3.0"]
+    branches: [main, master, "1.3.0", "release/**"]
   # Manual trigger for one-off debugging without pushing.
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Closes #317.
- `.github/workflows/ci.yml` only ran on PRs targeting `main`, `master`, or `1.3.0`. Every in-flight 2.3.0 PR targets `release/2.3.0`, which wasn't in that list, so the whole 2.3.0 line has been landing with zero automated test coverage.
- Added `release/**` to the `pull_request.branches` trigger. Covers `release/2.3.0` and future release branches without needing another edit each cycle.
- Confirmed the Installer Preview and Portable Preview workflows don't need the same fix: they already trigger on `pull_request` with no `branches` filter at all, gated purely by the `build-installer` label in their job-level `if` condition.

This is exactly how the 4 new language PRs' post-merge 253-key coverage gap (#318) went unnoticed: each PR is individually correct on its own branch, but CI never ran the merged state to catch the drift.

## Testing Checklist
- [x] PR is scoped to one concern (CI trigger config only, no app code changed)
- [x] `pytest tests/` passes locally (1330 passed, 21 skipped, same 5 pre-existing Chinese/Italian/Japanese failures CI would now catch — the exact #318 gap)
- [x] Target branch is the active `release/2.3.0`, not `main`

## Testing performed
Validated the YAML parses correctly with the new trigger list. Ran the full test suite locally against the current release/2.3.0 tip to confirm this change wouldn't be silently masking anything else.

---
🤖 PR description generated with [Claude Code](https://claude.com/claude-code)
