### PR TITLE
[#318] Post-merge i18n backfill for Chinese, Italian, Japanese

### DIFF
--- a/languages/chinese/ui.json
+++ b/languages/chinese/ui.json
@@ -35,6 +35,22 @@
     "defaults_hint": {
       "ht": "",
       "at": "使用你当前的设置（与高级视图显示的相同）。\n首次运行在提取 DataForge 时可能需要几分钟。"
+    },
+    "set_game_folder_title": {
+      "ht": "",
+      "at": "设置你的游戏文件夹"
+    },
+    "set_game_folder_body": {
+      "ht": "",
+      "at": "Smart Citizen 需要知道 Star Citizen 的安装位置才能应用更改。\n\n即将切换到高级模式，以便你在配置标签页设置游戏文件夹。"
+    },
+    "apply_enhancements_confirm_title": {
+      "ht": "",
+      "at": "应用增强内容"
+    },
+    "apply_enhancements_confirm_body": {
+      "ht": "",
+      "at": "这将使用你当前的设置生成最新的增强内容，并应用到游戏的 global.ini。系统会先创建一个带时间戳的备份。\n\n首次运行可能需要几分钟，因为需要提取 DataForge。是否继续？"
     }
   },
   "tabs": {
@@ -69,6 +85,18 @@
     "legal": {
       "ht": "",
       "at": "法律信息"
+    },
+    "about_load_failed": {
+      "ht": "",
+      "at": "无法加载关于信息。"
+    },
+    "faq_load_failed": {
+      "ht": "",
+      "at": "无法加载常见问题。"
+    },
+    "legal_load_failed": {
+      "ht": "",
+      "at": "无法加载法律信息。"
     }
   },
   "toolbar": {
@@ -175,6 +203,18 @@
     "apply_disabled_tooltip": {
       "ht": "",
       "at": "已经应用：自上次应用到游戏以来没有任何更改。"
+    },
+    "feedback_fallback_text": {
+      "ht": "",
+      "at": "反馈、错误报告与功能投票"
+    },
+    "paypal_fallback_text": {
+      "ht": "",
+      "at": "通过 PayPal 捐赠"
+    },
+    "venmo_fallback_text": {
+      "ht": "",
+      "at": "Venmo"
     }
   },
   "filters": {
@@ -339,6 +379,66 @@
     "column_filter_placeholder": {
       "ht": "",
       "at": "筛选 {column}…"
+    },
+    "editor_dock_title": {
+      "ht": "",
+      "at": "字符串编辑器"
+    },
+    "no_row_selected": {
+      "ht": "",
+      "at": "（未选择任何行）"
+    },
+    "editor_underline_btn": {
+      "ht": "",
+      "at": "下划线"
+    },
+    "editor_highlight_btn": {
+      "ht": "",
+      "at": "高亮"
+    },
+    "editor_placeholder": {
+      "ht": "",
+      "at": "在字符串编辑器表格中选择一行，即可在此编辑其自定义值。"
+    },
+    "context_copy_cell": {
+      "ht": "",
+      "at": "复制单元格"
+    },
+    "context_copy_key": {
+      "ht": "",
+      "at": "复制键名"
+    },
+    "context_edit": {
+      "ht": "",
+      "at": "编辑"
+    },
+    "context_reset_to_original": {
+      "ht": "",
+      "at": "重置为原始值"
+    },
+    "context_copy_all_filtered": {
+      "ht": "",
+      "at": "复制所有筛选结果"
+    },
+    "context_remove_favorite": {
+      "ht": "",
+      "at": "★ 取消收藏"
+    },
+    "context_add_favorite": {
+      "ht": "",
+      "at": "★ 添加到收藏"
+    },
+    "showing_count": {
+      "ht": "",
+      "at": "显示 {total} 个字符串中的 {shown} 个"
+    },
+    "copied_key": {
+      "ht": "",
+      "at": "已复制：{loc_key}"
+    },
+    "pyperclip_missing": {
+      "ht": "",
+      "at": "未安装 pyperclip"
     }
   },
   "config": {
@@ -661,6 +761,46 @@
     "extract_tooltip": {
       "ht": "",
       "at": "从你已安装的 Data.p4k 中解包官方本地化内容（base.ini）以及 DataForge 实体 XML。每次《星际公民》更新后运行——提取完成后字符串会自动重新加载到表格中。"
+    },
+    "include_new_cb": {
+      "ht": "",
+      "at": "包含新发现的项目"
+    },
+    "disable_tutorial_cb": {
+      "ht": "",
+      "at": "禁用教程"
+    },
+    "invalid_data_folder_body": {
+      "ht": "",
+      "at": "所选的数据文件夹是一个文件，而不是目录：\n{path}"
+    },
+    "onedrive_folder_title": {
+      "ht": "",
+      "at": "数据文件夹位于 OneDrive 中"
+    },
+    "onedrive_folder_body": {
+      "ht": "",
+      "at": "此文件夹位于 OneDrive 中：\n\n{path}\n\nOneDrive 可能会同步甚至清空这些文件，已导致过编辑内容丢失。强烈建议使用 OneDrive 之外的本地文件夹。\n\n仍要使用此 OneDrive 文件夹吗？"
+    },
+    "dataforge_cache_old_new": {
+      "ht": "",
+      "at": "旧：{old}\n新：{new}"
+    },
+    "channel_not_installed_hint": {
+      "ht": "",
+      "at": "⚠ 此根目录下未安装 {channel} — 请选择其他频道"
+    },
+    "preview_merge_failed": {
+      "ht": "",
+      "at": "预览合并失败：{error}"
+    },
+    "game_path_placeholder": {
+      "ht": "",
+      "at": "C:\\Program Files\\Roberts Space Industries\\StarCitizen"
+    },
+    "language_source_placeholder": {
+      "ht": "",
+      "at": "https://…/global.ini"
     }
   },
   "enhancements": {
@@ -923,6 +1063,246 @@
     "extracting_dataforge_tooltip": {
       "ht": "",
       "at": "正在从 Data.p4k 提取 DataForge…"
+    },
+    "tag_move_up_tooltip": {
+      "ht": "",
+      "at": "上移此元素"
+    },
+    "tag_move_down_tooltip": {
+      "ht": "",
+      "at": "下移此元素"
+    },
+    "tag_untick_exclude_tooltip": {
+      "ht": "",
+      "at": "取消勾选可将此元素从标签中排除"
+    },
+    "tag_edit_mapping_row_btn": {
+      "ht": "",
+      "at": "编辑映射…"
+    },
+    "tag_mapping_tooltip_ordinance": {
+      "ht": "",
+      "at": "编辑每种追踪类型使用的短/中/长文本（例如：Infrared → I / IR / Infrared）。"
+    },
+    "tag_mapping_tooltip_damage": {
+      "ht": "",
+      "at": "编辑每种伤害类型使用的短/中/长文本（例如：Energy → E / EN / Energy）。"
+    },
+    "tag_mapping_tooltip_type": {
+      "ht": "",
+      "at": "编辑每种组件类型使用的短/中/长文本（例如：Shield Generator → SH / SHLD / Shield）。"
+    },
+    "tag_mapping_tooltip_label": {
+      "ht": "",
+      "at": "编辑制造标签的短/中/长文本（例如：Crafting → CF / Craft / Crafting）。"
+    },
+    "tag_mapping_tooltip_collection": {
+      "ht": "",
+      "at": "编辑收藏标签的短/中/长文本（例如：Collection → Col / Collect / Collection）。"
+    },
+    "tag_mapping_tooltip_default": {
+      "ht": "",
+      "at": "编辑每个等级使用的短/中/长文本（例如：Military → M / MIL / Military）。"
+    },
+    "mission_detail_fields_heading": {
+      "ht": "",
+      "at": "任务详情字段："
+    },
+    "mission_field_mission_type": {
+      "ht": "",
+      "at": "任务类型"
+    },
+    "mission_field_difficulty": {
+      "ht": "",
+      "at": "难度"
+    },
+    "mission_field_hostiles": {
+      "ht": "",
+      "at": "敌对数量"
+    },
+    "mission_field_reputation": {
+      "ht": "",
+      "at": "声望"
+    },
+    "mission_field_blueprints": {
+      "ht": "",
+      "at": "蓝图"
+    },
+    "mission_field_ace_pilot": {
+      "ht": "",
+      "at": "王牌飞行员"
+    },
+    "mission_detail_fields_note": {
+      "ht": "",
+      "at": "未勾选的字段不会出现在任务描述中。下次生成增强内容时生效。"
+    },
+    "stats_prepend_cb": {
+      "ht": "",
+      "at": "在描述上方显示属性数据"
+    },
+    "standardize_ship_names_cb": {
+      "ht": "",
+      "at": "统一可获取飞船的名称"
+    },
+    "mission_labels_group": {
+      "ht": "",
+      "at": "任务标签"
+    },
+    "mission_label_details": {
+      "ht": "",
+      "at": "详情："
+    },
+    "mission_label_blueprints": {
+      "ht": "",
+      "at": "蓝图："
+    },
+    "mission_label_item_rewards": {
+      "ht": "",
+      "at": "物品奖励："
+    },
+    "mission_label_blueprint_data": {
+      "ht": "",
+      "at": "蓝图数据："
+    },
+    "mission_label_xp": {
+      "ht": "",
+      "at": "经验值标签："
+    },
+    "mission_label_header_style": {
+      "ht": "",
+      "at": "标题样式："
+    },
+    "em_label_underline": {
+      "ht": "",
+      "at": "下划线"
+    },
+    "em_label_blue_text": {
+      "ht": "",
+      "at": "蓝色文字"
+    },
+    "forge_status_not_extracted": {
+      "ht": "",
+      "at": "DataForge：尚未提取 — 点击“生成增强内容”开始"
+    },
+    "forge_status_outdated": {
+      "ht": "",
+      "at": "DataForge：缓存已过期 — 点击“生成增强内容”以重新提取并更新"
+    },
+    "forge_status_up_to_date": {
+      "ht": "",
+      "at": "DataForge：缓存已是最新 ✓"
+    },
+    "tag_separator_label": {
+      "ht": "",
+      "at": "分隔符："
+    },
+    "tag_enclosing_label": {
+      "ht": "",
+      "at": "括号样式："
+    },
+    "tag_placement_label": {
+      "ht": "",
+      "at": "放置位置："
+    },
+    "tag_craft_usage_separator_label": {
+      "ht": "",
+      "at": "用途分隔符："
+    },
+    "mt_hauling_group": {
+      "ht": "",
+      "at": "运输任务"
+    },
+    "mt_enable_route_cb": {
+      "ht": "",
+      "at": "在运输任务标题中添加路线"
+    },
+    "mt_standardize_cb": {
+      "ht": "",
+      "at": "统一运输任务名称（例如所有公司统一显示为“Medium Cargo Haul”，而不是“Large Shipment” / “Haul - Small Scale”）"
+    },
+    "mt_route_hint": {
+      "ht": "",
+      "at": "接受任务后，游戏会自动填入实际的取货和送货地点。"
+    },
+    "mt_route_arrow_label": {
+      "ht": "",
+      "at": "路线箭头："
+    },
+    "mt_title_separator_label": {
+      "ht": "",
+      "at": "标题分隔符："
+    },
+    "mt_rank_separator_label": {
+      "ht": "",
+      "at": "等级分隔符："
+    },
+    "mt_location_detail_label": {
+      "ht": "",
+      "at": "地点详细程度："
+    },
+    "mt_shorten_titles_cb": {
+      "ht": "",
+      "at": "缩短原始标题（缩短常见短语，例如“Local Shipment Route” → “Route”）"
+    },
+    "mt_shorten_sizes_cb": {
+      "ht": "",
+      "at": "缩短货舱容量（缩写货舱等级，例如“Extra Small” → “XS”）"
+    },
+    "mt_underline_direct_cb": {
+      "ht": "",
+      "at": "为“Direct”加下划线（在游戏中突出显示“Direct”运输任务）"
+    },
+    "mt_general_tags_group": {
+      "ht": "",
+      "at": "通用标签"
+    },
+    "mt_general_tags_hint": {
+      "ht": "",
+      "at": "仅在任务标题中显示或隐藏这些标签"
+    },
+    "mt_tag_rep_cb": {
+      "ht": "",
+      "at": "声望标签（添加“[500 REP]”）"
+    },
+    "mt_tag_blueprint_cb": {
+      "ht": "",
+      "at": "蓝图标签（添加“[BP]” / “[BP?]”）"
+    },
+    "mt_tag_ace_cb": {
+      "ht": "",
+      "at": "王牌标签（添加“[ACE]” / “[ACE?]”）"
+    },
+    "mt_tag_rep_track_cb": {
+      "ht": "",
+      "at": "声望轨道标签（在声望标签后添加“(Security)” / “(Contractor)”）"
+    },
+    "mt_scanning_group": {
+      "ht": "",
+      "at": "扫描/采矿任务"
+    },
+    "mt_scanning_hint": {
+      "ht": "",
+      "at": "Recco Battaglia 的扫描/采矿任务针对特定可开采矿物，会在任务标题中显示每种矿物的资源信号值。"
+    },
+    "mt_tag_rs_cb": {
+      "ht": "",
+      "at": "显示资源信号（RS）标签"
+    },
+    "mt_preview_route_off": {
+      "ht": "",
+      "at": "预览：  {display} [50 REP]  （路线已关闭）"
+    },
+    "mt_preview_route_on": {
+      "ht": "",
+      "at": "预览：  {display} [50 REP]"
+    },
+    "tag_preview": {
+      "ht": "",
+      "at": "预览：  {content}"
+    },
+    "tag_preview_no_tag": {
+      "ht": "",
+      "at": "预览：  {name}   （无标签 — 所有元素均为空或已禁用）"
     }
   },
   "blueprint_tracker": {
@@ -949,6 +1329,10 @@
     "apply_owned_tag_tooltip_disabled": {
       "ht": "",
       "at": "已是最新——自上次应用以来，你的已拥有列表没有变化。"
+    },
+    "owned_tags_refreshed": {
+      "ht": "",
+      "at": "[Owned] 标签已刷新，与你当前的已拥有列表保持一致。"
     }
   },
   "log": {
@@ -1056,7 +1440,7 @@
     },
     "custom_value_prompt": {
       "ht": "",
-      "at": "为该键输入自定义值：\n{key}"
+      "at": "为该键输入自定义值：\n{loc_key}"
     },
     "auto_add_summary": {
       "ht": "",
@@ -1431,6 +1815,38 @@
     "skip_generate_tooltip": {
       "ht": "",
       "at": "跳过生成增强内容，继续操作。你可以之后在增强内容标签页中运行它。"
+    },
+    "crash_error_title": {
+      "ht": "",
+      "at": "Smart Citizen — 错误"
+    },
+    "show_log_btn": {
+      "ht": "",
+      "at": "显示日志"
+    },
+    "dismiss_btn": {
+      "ht": "",
+      "at": "关闭"
+    },
+    "suppressed_errors_suffix": {
+      "ht": "",
+      "at": "\n\n（另有 {count} 个错误已被隐藏 — 详情请查看日志标签页）"
+    },
+    "failed_to_delete_global_ini": {
+      "ht": "",
+      "at": "删除 global.ini 失败：{error}"
+    },
+    "failed_to_merge_sources": {
+      "ht": "",
+      "at": "合并数据源失败：{error}"
+    },
+    "failed_to_load_sources": {
+      "ht": "",
+      "at": "加载数据源失败：{error}"
+    },
+    "app_title": {
+      "ht": "",
+      "at": "Smart Citizen"
     }
   },
   "progress": {
@@ -1497,6 +1913,30 @@
     "snapshot_diff": {
       "ht": "",
       "at": "正在为差异对比创建缓存快照…"
+    },
+    "syncing_sources": {
+      "ht": "",
+      "at": "正在同步数据源..."
+    },
+    "starting_up_title": {
+      "ht": "",
+      "at": "正在启动"
+    },
+    "enhancements_label": {
+      "ht": "",
+      "at": "正在从 DataForge 生成增强本地化内容…\n\n首次运行可能需要几分钟。"
+    },
+    "generating_enhancements_title": {
+      "ht": "",
+      "at": "正在生成增强内容"
+    },
+    "reloading_with_enhancements": {
+      "ht": "",
+      "at": "正在使用更新后的增强内容重新加载字符串…"
+    },
+    "reloading_after_user_ini_restore": {
+      "ht": "",
+      "at": "正在恢复 user.ini 后重新加载 {channel}..."
     }
   },
   "status_bar": {
@@ -1535,6 +1975,442 @@
     "open_release_page_tooltip": {
       "ht": "",
       "at": "打开 v{version} 的发布页面"
+    },
+    "downloading_ini": {
+      "ht": "",
+      "at": "正在下载 INI 文件..."
+    },
+    "starting_up": {
+      "ht": "",
+      "at": "正在启动 — 正在同步数据源..."
+    },
+    "generating_enhancements_background": {
+      "ht": "",
+      "at": "正在后台生成增强内容…"
+    },
+    "enhancements_generated_applying": {
+      "ht": "",
+      "at": "增强内容已生成 — 正在应用到游戏…"
+    },
+    "enhancements_generated_reloading": {
+      "ht": "",
+      "at": "增强内容已生成 — 正在重新加载条目…"
+    },
+    "enhancement_generation_failed": {
+      "ht": "",
+      "at": "增强内容生成失败 — 详情请查看日志标签页"
+    },
+    "user_ini_reset": {
+      "ht": "",
+      "at": "{channel} 的 user.ini 已重置（已创建备份）"
+    },
+    "user_ini_restored": {
+      "ht": "",
+      "at": "已恢复 {channel} 的 user.ini"
+    },
+    "channel_indicator": {
+      "ht": "",
+      "at": "频道：{channel}"
+    },
+    "channel_switched_extracting": {
+      "ht": "",
+      "at": "已切换到 {channel} — 正在提取 Data.p4k…"
+    },
+    "channel_switched_reloading": {
+      "ht": "",
+      "at": "已切换到 {channel} — 正在重新加载数据源…"
+    },
+    "data_folder_changed_extracting": {
+      "ht": "",
+      "at": "数据文件夹已更改为 {data_dir} — 正在提取 Data.p4k…"
+    },
+    "data_folder_changed_reloading": {
+      "ht": "",
+      "at": "数据文件夹已更改为 {data_dir} — 正在重新加载数据源…"
+    },
+    "cache_folder_changed": {
+      "ht": "",
+      "at": "DataForge 缓存文件夹已更改 — 正在从 Data.p4k 重新提取…"
+    },
+    "syncing_source": {
+      "ht": "",
+      "at": "正在同步 {source_name}..."
+    },
+    "source_updated": {
+      "ht": "",
+      "at": "已更新 ↑"
+    },
+    "source_offline": {
+      "ht": "",
+      "at": "（离线？）"
+    },
+    "entry_count": {
+      "ht": "",
+      "at": "{count} 个条目"
+    },
+    "override_count_suffix": {
+      "ht": "",
+      "at": " | {count} 项覆盖"
+    },
+    "manifest_missing": {
+      "ht": "",
+      "at": "SC {channel}（缺少清单）"
+    }
+  },
+  "import_flow": {
+    "source_dialog_title": {
+      "ht": "",
+      "at": "导入 INI 文件"
+    },
+    "source_dialog_label": {
+      "ht": "",
+      "at": "输入本地文件路径或网址："
+    },
+    "source_dialog_placeholder": {
+      "ht": "",
+      "at": "C:\\path\\to\\file.ini 或 https://example.com/file.ini"
+    },
+    "browse_btn": {
+      "ht": "",
+      "at": "浏览..."
+    },
+    "select_ini_file_title": {
+      "ht": "",
+      "at": "选择 INI 文件"
+    },
+    "ini_file_filter": {
+      "ht": "",
+      "at": "INI 文件 (*.ini);;所有文件 (*)"
+    },
+    "download_error_title": {
+      "ht": "",
+      "at": "下载错误"
+    },
+    "download_error_body": {
+      "ht": "",
+      "at": "下载失败：\n{source}\n\n{error}"
+    },
+    "no_base_data_title": {
+      "ht": "",
+      "at": "没有基础数据"
+    },
+    "no_base_data_body": {
+      "ht": "",
+      "at": "尚未加载基础 INI。请先从 Data.p4k 提取。"
+    },
+    "no_valid_keys_title": {
+      "ht": "",
+      "at": "没有有效的键"
+    },
+    "no_valid_keys_body": {
+      "ht": "",
+      "at": "导入的 {count} 个键中没有一个存在于 base.ini 中。\n所有键均已排除。"
+    },
+    "nothing_to_import_title": {
+      "ht": "",
+      "at": "没有可导入的内容"
+    },
+    "nothing_to_import_body": {
+      "ht": "",
+      "at": "所有导入的键在 user.ini 中已存在，且值相同。"
+    },
+    "confirm_title": {
+      "ht": "",
+      "at": "导入 INI"
+    },
+    "confirm_body": {
+      "ht": "",
+      "at": "将向 user.ini 添加 {new_count} 个新键。\n{excluded_count} 个键被排除（不在 base.ini 中）。\n\n是否继续？"
+    },
+    "reload_status": {
+      "ht": "",
+      "at": "正在使用导入的数据重新加载..."
+    },
+    "complete_title": {
+      "ht": "",
+      "at": "导入完成"
+    },
+    "complete_body": {
+      "ht": "",
+      "at": "导入成功。\n\n  已添加：{added} 个键\n  冲突已解决：{resolved} 个键\n  已排除：{excluded} 个键"
+    },
+    "error_title": {
+      "ht": "",
+      "at": "导入错误"
+    },
+    "error_body": {
+      "ht": "",
+      "at": "导入 INI 文件失败：\n{error}"
+    }
+  },
+  "restore_backup": {
+    "select_file_title": {
+      "ht": "",
+      "at": "选择要恢复的备份文件"
+    },
+    "file_filter": {
+      "ht": "",
+      "at": "备份文件 (*.bak_*);;INI 文件 (*.ini);;所有文件 (*)"
+    },
+    "success_body": {
+      "ht": "",
+      "at": "已从以下位置恢复备份：\n{name}"
+    },
+    "error_body": {
+      "ht": "",
+      "at": "恢复备份失败：{error}"
+    }
+  },
+  "onedrive": {
+    "warning_title": {
+      "ht": "",
+      "at": "你的 Smart Citizen 数据位于 OneDrive 中"
+    },
+    "warning_body": {
+      "ht": "",
+      "at": "Smart Citizen 将你的编辑内容（user.ini）、数据源缓存和备份存储在：\n\n{data_dir}\n\n该文件夹位于 OneDrive 中。OneDrive 可能会同步甚至清空这些文件，已导致过编辑内容丢失。将数据移动到 OneDrive 之外的本地文件夹可以避免此问题。\n\n是否移动到：\n{local} ？"
+    },
+    "move_btn": {
+      "ht": "",
+      "at": "移动到本地文件夹"
+    },
+    "keep_here_btn": {
+      "ht": "",
+      "at": "保留在此处"
+    },
+    "dont_warn_again": {
+      "ht": "",
+      "at": "不再提醒我"
+    }
+  },
+  "user_ini_reset": {
+    "backup_note": {
+      "ht": "",
+      "at": "\n\n备份已保存到：\n{path}"
+    },
+    "complete_title": {
+      "ht": "",
+      "at": "user.ini 已重置"
+    },
+    "complete_body": {
+      "ht": "",
+      "at": "{channel} 频道的所有自定义覆盖内容均已清除。{backup_note}"
+    }
+  },
+  "restore_user_ini": {
+    "no_snapshots_title": {
+      "ht": "",
+      "at": "尚无快照"
+    },
+    "no_snapshots_body": {
+      "ht": "",
+      "at": "Smart Citizen 目前还没有 {channel} 频道的自动 user.ini 快照。每次你更改覆盖内容时都会保存一个快照，因此在你进行并保存编辑后才会出现可恢复的还原点。"
+    },
+    "snapshot_label": {
+      "ht": "",
+      "at": "{when}  —  {lines} 项覆盖，{size_kb} KB"
+    },
+    "picker_title": {
+      "ht": "",
+      "at": "恢复 user.ini"
+    },
+    "picker_label": {
+      "ht": "",
+      "at": "为 {channel} 频道选择一个要恢复的快照。\n你当前的 user.ini 会先被保存为快照，因此此操作是可逆的。"
+    },
+    "restore_failed_title": {
+      "ht": "",
+      "at": "恢复失败"
+    },
+    "restore_failed_body": {
+      "ht": "",
+      "at": "Smart Citizen 无法恢复该快照：\n\n{error_type}：{error}"
+    },
+    "restored_title": {
+      "ht": "",
+      "at": "user.ini 已恢复"
+    },
+    "restored_body": {
+      "ht": "",
+      "at": "已从以下位置恢复 {channel} 频道的覆盖内容：\n{name}\n\n请运行“应用增强内容”将恢复的覆盖内容推送到游戏中。"
+    }
+  },
+  "extract": {
+    "path_required_title": {
+      "ht": "",
+      "at": "需要 Star Citizen 路径"
+    },
+    "path_required_body": {
+      "ht": "",
+      "at": "尚未配置 Star Citizen 安装路径，也未找到缓存的本地化数据。\n\n请在配置标签页设置你的 Star Citizen 安装路径，然后点击“提取”以加载游戏的本地化字符串。"
+    },
+    "p4k_prompt_title": {
+      "ht": "",
+      "at": "从 Data.p4k 提取"
+    },
+    "p4k_prompt_base_missing": {
+      "ht": "",
+      "at": "缓存中未找到基础本地化文件。\n\n现在从 Data.p4k 提取 global.ini 吗？\n（加载和显示本地化字符串需要此操作。）"
+    },
+    "p4k_prompt_p4k_newer": {
+      "ht": "",
+      "at": "Data.p4k 比你缓存的 base.ini 更新。\n\n现在从 Data.p4k 提取 global.ini 吗？\n（这将获取与你当前安装的游戏版本完全匹配的原版字符串。）"
+    },
+    "dataforge_outdated_title": {
+      "ht": "",
+      "at": "DataForge 缓存已过期"
+    },
+    "dataforge_outdated_body": {
+      "ht": "",
+      "at": "你的 DataForge 实体缓存比当前的 Data.p4k 更旧。\n\n现在重新提取 DataForge 并重新生成增强内容吗？\n\n此操作需要几分钟，并会在后台运行 — 你可以在此期间继续编辑字符串。如果不想等待，可以暂时跳过；你也可以随时从增强内容标签页触发此操作。"
+    },
+    "generate_dialog_title": {
+      "ht": "",
+      "at": "生成增强内容"
+    },
+    "category_singular": {
+      "ht": "",
+      "at": "。"
+    },
+    "category_plural": {
+      "ht": "",
+      "at": "。"
+    },
+    "missing_categories_body": {
+      "ht": "",
+      "at": "缺少 {count} 个增强类别{noun}\n请选择要生成的内容。\n你之后可以在增强内容标签页中更改此设置。"
+    },
+    "missing_category_label": {
+      "ht": "",
+      "at": "{label}  （缺失）"
+    },
+    "dataforge_auto_extract_note": {
+      "ht": "",
+      "at": "如果 DataForge 数据尚未缓存，将会自动提取。\n首次运行需要几分钟。"
+    },
+    "generate_btn": {
+      "ht": "",
+      "at": "生成"
+    },
+    "skip_btn": {
+      "ht": "",
+      "at": "跳过"
+    },
+    "dataforge_extracting_background": {
+      "ht": "",
+      "at": "正在后台提取 DataForge — 这需要几分钟…"
+    },
+    "dataforge_extracting_label": {
+      "ht": "",
+      "at": "正在从 Data.p4k 提取 DataForge — 这需要几分钟…"
+    },
+    "dataforge_extraction_title": {
+      "ht": "",
+      "at": "DataForge 提取"
+    },
+    "dataforge_extraction_error_title": {
+      "ht": "",
+      "at": "DataForge 提取错误"
+    },
+    "dataforge_extraction_error_body": {
+      "ht": "",
+      "at": "DataForge 提取失败：\n\n{message}\n\n详情请查看日志标签页。"
+    },
+    "dataforge_extracted_generating": {
+      "ht": "",
+      "at": "DataForge 已提取 — 正在生成增强内容…"
+    },
+    "dataforge_extraction_failed": {
+      "ht": "",
+      "at": "DataForge 提取失败 — 详情请查看日志标签页"
+    },
+    "p4k_extracting_label": {
+      "ht": "",
+      "at": "正在从 Data.p4k 提取 global.ini..."
+    },
+    "p4k_extraction_title": {
+      "ht": "",
+      "at": "P4K 提取"
+    },
+    "extraction_error_title": {
+      "ht": "",
+      "at": "提取错误"
+    }
+  },
+  "apply": {
+    "cannot_save_edits_title": {
+      "ht": "",
+      "at": "无法保存你的编辑内容"
+    },
+    "cannot_save_edits_body": {
+      "ht": "",
+      "at": "Smart Citizen 无法将你的编辑内容写入：\n\n  {path}\n\n{error_type}：{error}\n\n游戏文件未被修改。常见原因：\n  • 杀毒软件 / Windows 受控文件夹访问阻止了对游戏文件夹的写入\n  • user.ini 文件已在其他程序中打开\n  • 磁盘为只读或空间不足\n\n请解决相关问题后重新应用。"
+    },
+    "applied_body": {
+      "ht": "",
+      "at": "已应用到 {target_path}\n\n  用户编辑数：{user_count}\n\n{enhancement_block}"
+    },
+    "failed_body": {
+      "ht": "",
+      "at": "应用到游戏失败：{error}"
+    }
+  },
+  "test_plan": {
+    "intro": {
+      "ht": "",
+      "at": "逐项检查此构建版本中的每个项目，验证后请打勾。你的进度会自动保存。完成后，点击“复制报告”或“提交”来分享你的发现。"
+    },
+    "tester_label": {
+      "ht": "",
+      "at": "测试者："
+    },
+    "tester_placeholder": {
+      "ht": "",
+      "at": "你的名字或昵称"
+    },
+    "submit_btn": {
+      "ht": "",
+      "at": "提交到 Discord"
+    },
+    "no_webhook_tooltip": {
+      "ht": "",
+      "at": "尚未配置 Discord Webhook。请设置 {env_var} 环境变量（或 test_plan/webhook_url 设置项）以启用提交功能。在此之前请使用“复制报告”。"
+    },
+    "copy_report_btn": {
+      "ht": "",
+      "at": "复制报告"
+    },
+    "reset_btn": {
+      "ht": "",
+      "at": "重置"
+    },
+    "notes_label": {
+      "ht": "",
+      "at": "补充反馈（可选）："
+    },
+    "notes_placeholder": {
+      "ht": "",
+      "at": "描述任何错误、意外情况或建议..."
+    },
+    "copied_status": {
+      "ht": "",
+      "at": "报告已复制到剪贴板。"
+    },
+    "copy_failed_status": {
+      "ht": "",
+      "at": "无法将报告复制到剪贴板。"
+    },
+    "reset_status": {
+      "ht": "",
+      "at": "检查清单已重置。"
+    },
+    "no_webhook_status": {
+      "ht": "",
+      "at": "尚未配置 Discord Webhook。"
+    },
+    "sending_status": {
+      "ht": "",
+      "at": "正在将报告发送到 Discord..."
     }
   },
   "tutorial": {

--- a/languages/italian/ui.json
+++ b/languages/italian/ui.json
@@ -35,6 +35,22 @@
     "defaults_hint": {
       "ht": "",
       "at": "Usa le tue impostazioni attuali (le stesse mostrate nella vista Avanzata).\nLa prima esecuzione può richiedere alcuni minuti mentre DataForge viene estratto."
+    },
+    "set_game_folder_title": {
+      "ht": "",
+      "at": "Imposta la tua cartella di gioco"
+    },
+    "set_game_folder_body": {
+      "ht": "",
+      "at": "Smart Citizen deve sapere dove è installato Star Citizen prima di poter applicare le modifiche.\n\nPassaggio alla modalità Avanzata per impostare la cartella di gioco nella scheda Configurazione."
+    },
+    "apply_enhancements_confirm_title": {
+      "ht": "",
+      "at": "Applica Miglioramenti"
+    },
+    "apply_enhancements_confirm_body": {
+      "ht": "",
+      "at": "Questo genererà gli ultimi miglioramenti con le tue impostazioni attuali e li applicherà al global.ini del tuo gioco. Verrà prima creato un backup con data e ora.\n\nLa prima esecuzione può richiedere alcuni minuti mentre viene estratto DataForge. Continuare?"
     }
   },
   "tabs": {
@@ -69,6 +85,18 @@
     "legal": {
       "ht": "",
       "at": "Legale"
+    },
+    "about_load_failed": {
+      "ht": "",
+      "at": "Impossibile caricare le informazioni su Smart Citizen."
+    },
+    "faq_load_failed": {
+      "ht": "",
+      "at": "Impossibile caricare le FAQ."
+    },
+    "legal_load_failed": {
+      "ht": "",
+      "at": "Impossibile caricare le informazioni legali."
     }
   },
   "toolbar": {
@@ -175,6 +203,18 @@
     "apply_disabled_tooltip": {
       "ht": "",
       "at": "Già applicato: nulla è cambiato dall'ultima applicazione al gioco."
+    },
+    "feedback_fallback_text": {
+      "ht": "",
+      "at": "Feedback, Bug e Votazione Funzionalità"
+    },
+    "paypal_fallback_text": {
+      "ht": "",
+      "at": "Dona tramite PayPal"
+    },
+    "venmo_fallback_text": {
+      "ht": "",
+      "at": "Venmo"
     }
   },
   "filters": {
@@ -339,6 +379,66 @@
     "column_filter_placeholder": {
       "ht": "",
       "at": "Filtra {column}…"
+    },
+    "editor_dock_title": {
+      "ht": "",
+      "at": "Editor Stringhe"
+    },
+    "no_row_selected": {
+      "ht": "",
+      "at": "(nessuna riga selezionata)"
+    },
+    "editor_underline_btn": {
+      "ht": "",
+      "at": "Sottolineato"
+    },
+    "editor_highlight_btn": {
+      "ht": "",
+      "at": "Evidenzia"
+    },
+    "editor_placeholder": {
+      "ht": "",
+      "at": "Seleziona una riga nella tabella dell'Editor Stringhe per modificarne qui il valore personalizzato."
+    },
+    "context_copy_cell": {
+      "ht": "",
+      "at": "Copia Cella"
+    },
+    "context_copy_key": {
+      "ht": "",
+      "at": "Copia Chiave"
+    },
+    "context_edit": {
+      "ht": "",
+      "at": "Modifica"
+    },
+    "context_reset_to_original": {
+      "ht": "",
+      "at": "Ripristina Originale"
+    },
+    "context_copy_all_filtered": {
+      "ht": "",
+      "at": "Copia Tutti i Filtrati"
+    },
+    "context_remove_favorite": {
+      "ht": "",
+      "at": "★ Rimuovi dai Preferiti"
+    },
+    "context_add_favorite": {
+      "ht": "",
+      "at": "★ Aggiungi ai Preferiti"
+    },
+    "showing_count": {
+      "ht": "",
+      "at": "Visualizzazione di {shown} su {total} stringhe"
+    },
+    "copied_key": {
+      "ht": "",
+      "at": "Copiato: {loc_key}"
+    },
+    "pyperclip_missing": {
+      "ht": "",
+      "at": "pyperclip non installato"
     }
   },
   "config": {
@@ -661,6 +761,46 @@
     "extract_tooltip": {
       "ht": "",
       "at": "Estrai la localizzazione originale (base.ini) insieme agli XML delle entità DataForge dal tuo Data.p4k installato. Eseguilo dopo ogni patch di Star Citizen — le stringhe si ricaricano automaticamente nella tabella al termine dell'estrazione."
+    },
+    "include_new_cb": {
+      "ht": "",
+      "at": "Includi elementi scoperti"
+    },
+    "disable_tutorial_cb": {
+      "ht": "",
+      "at": "Disabilita Tutorial"
+    },
+    "invalid_data_folder_body": {
+      "ht": "",
+      "at": "La cartella dati selezionata è un file, non una directory:\n{path}"
+    },
+    "onedrive_folder_title": {
+      "ht": "",
+      "at": "Cartella Dati Dentro OneDrive"
+    },
+    "onedrive_folder_body": {
+      "ht": "",
+      "at": "Questa cartella si trova dentro OneDrive:\n\n{path}\n\nOneDrive può sincronizzare e persino svuotare questi file, causando la perdita di modifiche. Si consiglia vivamente una cartella locale al di fuori di OneDrive.\n\nUsare comunque questa cartella OneDrive?"
+    },
+    "dataforge_cache_old_new": {
+      "ht": "",
+      "at": "Vecchio: {old}\nNuovo: {new}"
+    },
+    "channel_not_installed_hint": {
+      "ht": "",
+      "at": "⚠ {channel} non è installato in questa radice — scegli un altro canale"
+    },
+    "preview_merge_failed": {
+      "ht": "",
+      "at": "Anteprima unione fallita: {error}"
+    },
+    "game_path_placeholder": {
+      "ht": "",
+      "at": "C:\\Program Files\\Roberts Space Industries\\StarCitizen"
+    },
+    "language_source_placeholder": {
+      "ht": "",
+      "at": "https://…/global.ini"
     }
   },
   "enhancements": {
@@ -923,6 +1063,246 @@
     "extracting_dataforge_tooltip": {
       "ht": "",
       "at": "Estrazione DataForge da Data.p4k…"
+    },
+    "tag_move_up_tooltip": {
+      "ht": "",
+      "at": "Sposta questo elemento in alto"
+    },
+    "tag_move_down_tooltip": {
+      "ht": "",
+      "at": "Sposta questo elemento in basso"
+    },
+    "tag_untick_exclude_tooltip": {
+      "ht": "",
+      "at": "Deseleziona per escludere questo elemento dal tag"
+    },
+    "tag_edit_mapping_row_btn": {
+      "ht": "",
+      "at": "Modifica mappatura…"
+    },
+    "tag_mapping_tooltip_ordinance": {
+      "ht": "",
+      "at": "Modifica il testo Breve / Medio / Lungo usato per ogni tipo di tracciamento (es. Infrared → I / IR / Infrared)."
+    },
+    "tag_mapping_tooltip_damage": {
+      "ht": "",
+      "at": "Modifica il testo Breve / Medio / Lungo usato per ogni tipo di danno (es. Energy → E / EN / Energy)."
+    },
+    "tag_mapping_tooltip_type": {
+      "ht": "",
+      "at": "Modifica il testo Breve / Medio / Lungo usato per ogni tipo di componente (es. Shield Generator → SH / SHLD / Shield)."
+    },
+    "tag_mapping_tooltip_label": {
+      "ht": "",
+      "at": "Modifica il testo Breve / Medio / Lungo per l'etichetta di crafting (es. Crafting → CF / Craft / Crafting)."
+    },
+    "tag_mapping_tooltip_collection": {
+      "ht": "",
+      "at": "Modifica il testo Breve / Medio / Lungo per l'etichetta collezione (es. Collection → Col / Collect / Collection)."
+    },
+    "tag_mapping_tooltip_default": {
+      "ht": "",
+      "at": "Modifica il testo Breve / Medio / Lungo usato per ogni classe (es. Military → M / MIL / Military)."
+    },
+    "mission_detail_fields_heading": {
+      "ht": "",
+      "at": "Campi dettagli missione:"
+    },
+    "mission_field_mission_type": {
+      "ht": "",
+      "at": "Tipo di Missione"
+    },
+    "mission_field_difficulty": {
+      "ht": "",
+      "at": "Difficoltà"
+    },
+    "mission_field_hostiles": {
+      "ht": "",
+      "at": "Ostili"
+    },
+    "mission_field_reputation": {
+      "ht": "",
+      "at": "Reputazione"
+    },
+    "mission_field_blueprints": {
+      "ht": "",
+      "at": "Progetti"
+    },
+    "mission_field_ace_pilot": {
+      "ht": "",
+      "at": "Pilota Asso"
+    },
+    "mission_detail_fields_note": {
+      "ht": "",
+      "at": "I campi deselezionati vengono esclusi dalle descrizioni delle missioni. Si applica al prossimo Genera Miglioramenti."
+    },
+    "stats_prepend_cb": {
+      "ht": "",
+      "at": "Mostra le statistiche sopra la descrizione"
+    },
+    "standardize_ship_names_cb": {
+      "ht": "",
+      "at": "Standardizza i nomi delle navi ottenibili"
+    },
+    "mission_labels_group": {
+      "ht": "",
+      "at": "Etichette Missione"
+    },
+    "mission_label_details": {
+      "ht": "",
+      "at": "Dettagli:"
+    },
+    "mission_label_blueprints": {
+      "ht": "",
+      "at": "Progetti:"
+    },
+    "mission_label_item_rewards": {
+      "ht": "",
+      "at": "Ricompense oggetti:"
+    },
+    "mission_label_blueprint_data": {
+      "ht": "",
+      "at": "Dati progetto:"
+    },
+    "mission_label_xp": {
+      "ht": "",
+      "at": "Etichetta XP:"
+    },
+    "mission_label_header_style": {
+      "ht": "",
+      "at": "Stile intestazione:"
+    },
+    "em_label_underline": {
+      "ht": "",
+      "at": "Sottolineato"
+    },
+    "em_label_blue_text": {
+      "ht": "",
+      "at": "Testo blu"
+    },
+    "forge_status_not_extracted": {
+      "ht": "",
+      "at": "DataForge: non ancora estratto — clicca su \"Genera Miglioramenti\" per iniziare"
+    },
+    "forge_status_outdated": {
+      "ht": "",
+      "at": "DataForge: cache non aggiornata — clicca su \"Genera Miglioramenti\" per ri-estrarre e aggiornare"
+    },
+    "forge_status_up_to_date": {
+      "ht": "",
+      "at": "DataForge: cache aggiornata ✓"
+    },
+    "tag_separator_label": {
+      "ht": "",
+      "at": "Separatore:"
+    },
+    "tag_enclosing_label": {
+      "ht": "",
+      "at": "Racchiusura:"
+    },
+    "tag_placement_label": {
+      "ht": "",
+      "at": "Posizione:"
+    },
+    "tag_craft_usage_separator_label": {
+      "ht": "",
+      "at": "Separatore utilizzo crafting:"
+    },
+    "mt_hauling_group": {
+      "ht": "",
+      "at": "Missioni di Trasporto"
+    },
+    "mt_enable_route_cb": {
+      "ht": "",
+      "at": "Aggiungi percorso ai titoli delle missioni di trasporto"
+    },
+    "mt_standardize_cb": {
+      "ht": "",
+      "at": "Standardizza i nomi delle missioni di trasporto (es. \"Medium Cargo Haul\" per ogni azienda, invece di \"Large Shipment\" / \"Haul - Small Scale\")"
+    },
+    "mt_route_hint": {
+      "ht": "",
+      "at": "Il gioco inserisce i veri punti di ritiro e consegna quando la missione viene accettata."
+    },
+    "mt_route_arrow_label": {
+      "ht": "",
+      "at": "Freccia percorso:"
+    },
+    "mt_title_separator_label": {
+      "ht": "",
+      "at": "Separatore titolo:"
+    },
+    "mt_rank_separator_label": {
+      "ht": "",
+      "at": "Separatore rango:"
+    },
+    "mt_location_detail_label": {
+      "ht": "",
+      "at": "Dettaglio posizione:"
+    },
+    "mt_shorten_titles_cb": {
+      "ht": "",
+      "at": "Abbrevia titoli originali (Abbrevia le frasi standard, es. \"Local Shipment Route\" → \"Route\")"
+    },
+    "mt_shorten_sizes_cb": {
+      "ht": "",
+      "at": "Abbrevia dimensioni carico (Abbrevia le dimensioni del carico, es. \"Extra Small\" → \"XS\")"
+    },
+    "mt_underline_direct_cb": {
+      "ht": "",
+      "at": "Sottolinea \"Direct\" (Aggiunge enfasi ai trasporti \"Direct\" in gioco)"
+    },
+    "mt_general_tags_group": {
+      "ht": "",
+      "at": "Tag Generali"
+    },
+    "mt_general_tags_hint": {
+      "ht": "",
+      "at": "Mostra o nascondi questi tag solo nel titolo della missione"
+    },
+    "mt_tag_rep_cb": {
+      "ht": "",
+      "at": "Tag Reputazione (aggiunge \"[500 REP]\")"
+    },
+    "mt_tag_blueprint_cb": {
+      "ht": "",
+      "at": "Tag BP (aggiunge \"[BP]\" / \"[BP?]\")"
+    },
+    "mt_tag_ace_cb": {
+      "ht": "",
+      "at": "Tag ACE (aggiunge \"[ACE]\" / \"[ACE?]\")"
+    },
+    "mt_tag_rep_track_cb": {
+      "ht": "",
+      "at": "Tag Traccia Reputazione (aggiunge \"(Security)\" / \"(Contractor)\" al tag Reputazione)"
+    },
+    "mt_scanning_group": {
+      "ht": "",
+      "at": "Missioni di Scansione/Estrazione"
+    },
+    "mt_scanning_hint": {
+      "ht": "",
+      "at": "Le missioni di Scansione/Estrazione di Recco Battaglia hanno come bersaglio minerali estraibili specifici; mostrano il valore di Firma di Risorsa di ogni minerale nel titolo della missione."
+    },
+    "mt_tag_rs_cb": {
+      "ht": "",
+      "at": "Mostra Tag Firma di Risorsa (RS)"
+    },
+    "mt_preview_route_off": {
+      "ht": "",
+      "at": "Anteprima:  {display} [50 REP]  (percorso disattivato)"
+    },
+    "mt_preview_route_on": {
+      "ht": "",
+      "at": "Anteprima:  {display} [50 REP]"
+    },
+    "tag_preview": {
+      "ht": "",
+      "at": "Anteprima:  {content}"
+    },
+    "tag_preview_no_tag": {
+      "ht": "",
+      "at": "Anteprima:  {name}   (nessun tag — ogni elemento è vuoto o disabilitato)"
     }
   },
   "blueprint_tracker": {
@@ -949,6 +1329,10 @@
     "apply_owned_tag_tooltip_disabled": {
       "ht": "",
       "at": "Già aggiornato — la tua lista dei posseduti non è cambiata dall'ultima applicazione."
+    },
+    "owned_tags_refreshed": {
+      "ht": "",
+      "at": "I tag [Owned] sono stati aggiornati in base alla tua lista Posseduti attuale."
     }
   },
   "log": {
@@ -1056,7 +1440,7 @@
     },
     "custom_value_prompt": {
       "ht": "",
-      "at": "Inserisci il valore personalizzato per la chiave:\n{key}"
+      "at": "Inserisci il valore personalizzato per la chiave:\n{loc_key}"
     },
     "auto_add_summary": {
       "ht": "",
@@ -1431,6 +1815,38 @@
     "skip_generate_tooltip": {
       "ht": "",
       "at": "Continua senza generare i miglioramenti. Puoi farlo più tardi dalla scheda Miglioramenti."
+    },
+    "crash_error_title": {
+      "ht": "",
+      "at": "Smart Citizen — Errore"
+    },
+    "show_log_btn": {
+      "ht": "",
+      "at": "Mostra Log"
+    },
+    "dismiss_btn": {
+      "ht": "",
+      "at": "Ignora"
+    },
+    "suppressed_errors_suffix": {
+      "ht": "",
+      "at": "\n\n(+{count} errori aggiuntivi soppressi — vedi la scheda Log per i dettagli)"
+    },
+    "failed_to_delete_global_ini": {
+      "ht": "",
+      "at": "Eliminazione di global.ini fallita: {error}"
+    },
+    "failed_to_merge_sources": {
+      "ht": "",
+      "at": "Unione delle fonti fallita: {error}"
+    },
+    "failed_to_load_sources": {
+      "ht": "",
+      "at": "Caricamento delle fonti fallito: {error}"
+    },
+    "app_title": {
+      "ht": "",
+      "at": "Smart Citizen"
     }
   },
   "progress": {
@@ -1497,6 +1913,30 @@
     "snapshot_diff": {
       "ht": "",
       "at": "Creazione di uno snapshot della cache per il confronto…"
+    },
+    "syncing_sources": {
+      "ht": "",
+      "at": "Sincronizzazione fonti in corso..."
+    },
+    "starting_up_title": {
+      "ht": "",
+      "at": "Avvio in corso"
+    },
+    "enhancements_label": {
+      "ht": "",
+      "at": "Generazione delle localizzazioni migliorate da DataForge…\n\nQuesto può richiedere alcuni minuti alla prima esecuzione."
+    },
+    "generating_enhancements_title": {
+      "ht": "",
+      "at": "Generazione Miglioramenti"
+    },
+    "reloading_with_enhancements": {
+      "ht": "",
+      "at": "Ricaricamento delle stringhe con i miglioramenti aggiornati…"
+    },
+    "reloading_after_user_ini_restore": {
+      "ht": "",
+      "at": "Ricaricamento di {channel} dopo il ripristino di user.ini..."
     }
   },
   "status_bar": {
@@ -1535,6 +1975,442 @@
     "open_release_page_tooltip": {
       "ht": "",
       "at": "Apri la pagina di rilascio per v{version}"
+    },
+    "downloading_ini": {
+      "ht": "",
+      "at": "Download del file INI in corso..."
+    },
+    "starting_up": {
+      "ht": "",
+      "at": "Avvio in corso — sincronizzazione fonti..."
+    },
+    "generating_enhancements_background": {
+      "ht": "",
+      "at": "Generazione dei miglioramenti in background…"
+    },
+    "enhancements_generated_applying": {
+      "ht": "",
+      "at": "Miglioramenti generati — applicazione al gioco…"
+    },
+    "enhancements_generated_reloading": {
+      "ht": "",
+      "at": "Miglioramenti generati — ricaricamento voci…"
+    },
+    "enhancement_generation_failed": {
+      "ht": "",
+      "at": "Generazione dei miglioramenti fallita — controlla la scheda Log per i dettagli"
+    },
+    "user_ini_reset": {
+      "ht": "",
+      "at": "user.ini reimpostato per {channel} (backup creato)"
+    },
+    "user_ini_restored": {
+      "ht": "",
+      "at": "user.ini ripristinato per {channel}"
+    },
+    "channel_indicator": {
+      "ht": "",
+      "at": "Canale: {channel}"
+    },
+    "channel_switched_extracting": {
+      "ht": "",
+      "at": "Passato a {channel} — estrazione di Data.p4k…"
+    },
+    "channel_switched_reloading": {
+      "ht": "",
+      "at": "Passato a {channel} — ricaricamento fonti…"
+    },
+    "data_folder_changed_extracting": {
+      "ht": "",
+      "at": "Cartella dati cambiata in {data_dir} — estrazione di Data.p4k…"
+    },
+    "data_folder_changed_reloading": {
+      "ht": "",
+      "at": "Cartella dati cambiata in {data_dir} — ricaricamento fonti…"
+    },
+    "cache_folder_changed": {
+      "ht": "",
+      "at": "Cartella cache DataForge cambiata — ri-estrazione da Data.p4k…"
+    },
+    "syncing_source": {
+      "ht": "",
+      "at": "Sincronizzazione di {source_name}..."
+    },
+    "source_updated": {
+      "ht": "",
+      "at": "aggiornato ↑"
+    },
+    "source_offline": {
+      "ht": "",
+      "at": "(offline?)"
+    },
+    "entry_count": {
+      "ht": "",
+      "at": "{count} voci"
+    },
+    "override_count_suffix": {
+      "ht": "",
+      "at": " | {count} sovrascritture"
+    },
+    "manifest_missing": {
+      "ht": "",
+      "at": "SC {channel} (manifest mancante)"
+    }
+  },
+  "import_flow": {
+    "source_dialog_title": {
+      "ht": "",
+      "at": "Importa File INI"
+    },
+    "source_dialog_label": {
+      "ht": "",
+      "at": "Inserisci un percorso file locale o un URL:"
+    },
+    "source_dialog_placeholder": {
+      "ht": "",
+      "at": "C:\\percorso\\del\\file.ini o https://example.com/file.ini"
+    },
+    "browse_btn": {
+      "ht": "",
+      "at": "Sfoglia..."
+    },
+    "select_ini_file_title": {
+      "ht": "",
+      "at": "Seleziona File INI"
+    },
+    "ini_file_filter": {
+      "ht": "",
+      "at": "File INI (*.ini);;Tutti i File (*)"
+    },
+    "download_error_title": {
+      "ht": "",
+      "at": "Errore di Download"
+    },
+    "download_error_body": {
+      "ht": "",
+      "at": "Download fallito:\n{source}\n\n{error}"
+    },
+    "no_base_data_title": {
+      "ht": "",
+      "at": "Nessun Dato Base"
+    },
+    "no_base_data_body": {
+      "ht": "",
+      "at": "INI base non ancora caricato. Estrai prima da Data.p4k."
+    },
+    "no_valid_keys_title": {
+      "ht": "",
+      "at": "Nessuna Chiave Valida"
+    },
+    "no_valid_keys_body": {
+      "ht": "",
+      "at": "Nessuna delle {count} chiavi importate esiste in base.ini.\nTutte le chiavi sono state escluse."
+    },
+    "nothing_to_import_title": {
+      "ht": "",
+      "at": "Niente da Importare"
+    },
+    "nothing_to_import_body": {
+      "ht": "",
+      "at": "Tutte le chiavi importate esistono già in user.ini con gli stessi valori."
+    },
+    "confirm_title": {
+      "ht": "",
+      "at": "Importa INI"
+    },
+    "confirm_body": {
+      "ht": "",
+      "at": "{new_count} nuove chiavi verranno aggiunte a user.ini.\n{excluded_count} chiavi escluse (non presenti in base.ini).\n\nProcedere?"
+    },
+    "reload_status": {
+      "ht": "",
+      "at": "Ricaricamento con i dati importati..."
+    },
+    "complete_title": {
+      "ht": "",
+      "at": "Importazione Completata"
+    },
+    "complete_body": {
+      "ht": "",
+      "at": "Importazione riuscita.\n\n  Aggiunte: {added} chiavi\n  Conflitti risolti: {resolved} chiavi\n  Escluse: {excluded} chiavi"
+    },
+    "error_title": {
+      "ht": "",
+      "at": "Errore di Importazione"
+    },
+    "error_body": {
+      "ht": "",
+      "at": "Importazione del file INI fallita:\n{error}"
+    }
+  },
+  "restore_backup": {
+    "select_file_title": {
+      "ht": "",
+      "at": "Seleziona File di Backup da Ripristinare"
+    },
+    "file_filter": {
+      "ht": "",
+      "at": "File di Backup (*.bak_*);;File INI (*.ini);;Tutti i File (*)"
+    },
+    "success_body": {
+      "ht": "",
+      "at": "Backup ripristinato da:\n{name}"
+    },
+    "error_body": {
+      "ht": "",
+      "at": "Ripristino del backup fallito: {error}"
+    }
+  },
+  "onedrive": {
+    "warning_title": {
+      "ht": "",
+      "at": "I Tuoi Dati Smart Citizen Sono in OneDrive"
+    },
+    "warning_body": {
+      "ht": "",
+      "at": "Smart Citizen archivia le tue modifiche (user.ini), la cache delle fonti e i backup in:\n\n{data_dir}\n\nQuella cartella si trova dentro OneDrive. OneDrive può sincronizzare e persino svuotare questi file, causando la perdita di modifiche. Spostare i tuoi dati in una cartella locale al di fuori di OneDrive evita questo problema.\n\nSpostarli in:\n{local} ?"
+    },
+    "move_btn": {
+      "ht": "",
+      "at": "Sposta in una Cartella Locale"
+    },
+    "keep_here_btn": {
+      "ht": "",
+      "at": "Mantieni Qui"
+    },
+    "dont_warn_again": {
+      "ht": "",
+      "at": "Non avvisarmi più"
+    }
+  },
+  "user_ini_reset": {
+    "backup_note": {
+      "ht": "",
+      "at": "\n\nBackup salvato in:\n{path}"
+    },
+    "complete_title": {
+      "ht": "",
+      "at": "user.ini Reimpostato"
+    },
+    "complete_body": {
+      "ht": "",
+      "at": "Tutte le sovrascritture personalizzate per il canale {channel} sono state cancellate.{backup_note}"
+    }
+  },
+  "restore_user_ini": {
+    "no_snapshots_title": {
+      "ht": "",
+      "at": "Ancora Nessun Snapshot"
+    },
+    "no_snapshots_body": {
+      "ht": "",
+      "at": "Smart Citizen non ha ancora snapshot automatici di user.ini per il canale {channel}. Uno snapshot viene salvato ogni volta che le tue sovrascritture cambiano, quindi i punti di ripristino appaiono solo dopo aver effettuato e salvato delle modifiche."
+    },
+    "snapshot_label": {
+      "ht": "",
+      "at": "{when}  —  {lines} sovrascritture, {size_kb} KB"
+    },
+    "picker_title": {
+      "ht": "",
+      "at": "Ripristina user.ini"
+    },
+    "picker_label": {
+      "ht": "",
+      "at": "Scegli uno snapshot da ripristinare per il canale {channel}.\nIl tuo user.ini attuale viene prima salvato come snapshot, quindi questa operazione è reversibile."
+    },
+    "restore_failed_title": {
+      "ht": "",
+      "at": "Ripristino Fallito"
+    },
+    "restore_failed_body": {
+      "ht": "",
+      "at": "Smart Citizen non è riuscito a ripristinare lo snapshot:\n\n{error_type}: {error}"
+    },
+    "restored_title": {
+      "ht": "",
+      "at": "user.ini Ripristinato"
+    },
+    "restored_body": {
+      "ht": "",
+      "at": "Le tue sovrascritture per il canale {channel} sono state ripristinate da:\n{name}\n\nEsegui Applica Miglioramenti per inviare le sovrascritture ripristinate nel gioco."
+    }
+  },
+  "extract": {
+    "path_required_title": {
+      "ht": "",
+      "at": "Percorso Star Citizen Richiesto"
+    },
+    "path_required_body": {
+      "ht": "",
+      "at": "Nessun percorso di installazione di Star Citizen configurato e nessun dato di localizzazione in cache trovato.\n\nImposta il percorso di installazione di Star Citizen nella scheda Configurazione, quindi clicca su Estrai per caricare le stringhe di localizzazione del tuo gioco."
+    },
+    "p4k_prompt_title": {
+      "ht": "",
+      "at": "Estrai da Data.p4k"
+    },
+    "p4k_prompt_base_missing": {
+      "ht": "",
+      "at": "Nessun file di localizzazione base trovato nella cache.\n\nEstrarre ora global.ini da Data.p4k?\n(Necessario per caricare e visualizzare le stringhe di localizzazione.)"
+    },
+    "p4k_prompt_p4k_newer": {
+      "ht": "",
+      "at": "Data.p4k è più recente del tuo base.ini in cache.\n\nEstrarre ora global.ini da Data.p4k?\n(Questo ti darà le stringhe originali corrispondenti alla tua versione di gioco esattamente installata.)"
+    },
+    "dataforge_outdated_title": {
+      "ht": "",
+      "at": "Cache DataForge Non Aggiornata"
+    },
+    "dataforge_outdated_body": {
+      "ht": "",
+      "at": "La tua cache delle entità DataForge è più vecchia dell'attuale Data.p4k.\n\nRi-estrarre DataForge e rigenerare i miglioramenti ora?\n\nQuesto richiede alcuni minuti e viene eseguito in background — puoi continuare a modificare le stringhe mentre lavora. Salta per ora se preferisci non aspettare; puoi sempre avviarlo dalla scheda Miglioramenti."
+    },
+    "generate_dialog_title": {
+      "ht": "",
+      "at": "Genera Miglioramenti"
+    },
+    "category_singular": {
+      "ht": "",
+      "at": "categoria manca"
+    },
+    "category_plural": {
+      "ht": "",
+      "at": "categorie mancano"
+    },
+    "missing_categories_body": {
+      "ht": "",
+      "at": "{count} {noun}.\nSeleziona quali generare.\nPuoi cambiare questo in seguito nella scheda Miglioramenti."
+    },
+    "missing_category_label": {
+      "ht": "",
+      "at": "{label}  (mancante)"
+    },
+    "dataforge_auto_extract_note": {
+      "ht": "",
+      "at": "I dati DataForge verranno estratti automaticamente se non già in cache.\nLa prima esecuzione richiede alcuni minuti."
+    },
+    "generate_btn": {
+      "ht": "",
+      "at": "Genera"
+    },
+    "skip_btn": {
+      "ht": "",
+      "at": "Salta"
+    },
+    "dataforge_extracting_background": {
+      "ht": "",
+      "at": "Estrazione di DataForge in background — richiede diversi minuti…"
+    },
+    "dataforge_extracting_label": {
+      "ht": "",
+      "at": "Estrazione di DataForge da Data.p4k — richiede diversi minuti…"
+    },
+    "dataforge_extraction_title": {
+      "ht": "",
+      "at": "Estrazione DataForge"
+    },
+    "dataforge_extraction_error_title": {
+      "ht": "",
+      "at": "Errore di Estrazione DataForge"
+    },
+    "dataforge_extraction_error_body": {
+      "ht": "",
+      "at": "Estrazione di DataForge fallita:\n\n{message}\n\nControlla la scheda Log per i dettagli."
+    },
+    "dataforge_extracted_generating": {
+      "ht": "",
+      "at": "DataForge estratto — generazione miglioramenti…"
+    },
+    "dataforge_extraction_failed": {
+      "ht": "",
+      "at": "Estrazione di DataForge fallita — controlla la scheda Log per i dettagli"
+    },
+    "p4k_extracting_label": {
+      "ht": "",
+      "at": "Estrazione di global.ini da Data.p4k..."
+    },
+    "p4k_extraction_title": {
+      "ht": "",
+      "at": "Estrazione P4K"
+    },
+    "extraction_error_title": {
+      "ht": "",
+      "at": "Errore di Estrazione"
+    }
+  },
+  "apply": {
+    "cannot_save_edits_title": {
+      "ht": "",
+      "at": "Impossibile Salvare le Tue Modifiche"
+    },
+    "cannot_save_edits_body": {
+      "ht": "",
+      "at": "Smart Citizen non è riuscito a scrivere le tue modifiche in:\n\n  {path}\n\n{error_type}: {error}\n\nIl file di gioco NON è stato modificato. Cause comuni:\n  • Antivirus / Accesso controllato cartelle di Windows che blocca le scritture nella cartella di gioco\n  • Il file user.ini è aperto in un altro programma\n  • L'unità è di sola lettura o senza spazio\n\nRisolvi il problema di fondo e applica di nuovo."
+    },
+    "applied_body": {
+      "ht": "",
+      "at": "Applicato a {target_path}\n\n  Modifiche utente: {user_count}\n\n{enhancement_block}"
+    },
+    "failed_body": {
+      "ht": "",
+      "at": "Applicazione al gioco fallita: {error}"
+    }
+  },
+  "test_plan": {
+    "intro": {
+      "ht": "",
+      "at": "Esamina ogni voce di questa build e spuntala man mano che la verifichi. I tuoi progressi vengono salvati automaticamente. Quando hai finito, usa Copia Report o Invia per condividere quello che hai trovato."
+    },
+    "tester_label": {
+      "ht": "",
+      "at": "Tester:"
+    },
+    "tester_placeholder": {
+      "ht": "",
+      "at": "Il tuo nome o nickname"
+    },
+    "submit_btn": {
+      "ht": "",
+      "at": "Invia a Discord"
+    },
+    "no_webhook_tooltip": {
+      "ht": "",
+      "at": "Nessun webhook Discord configurato. Imposta la variabile d'ambiente {env_var} (o l'impostazione test_plan/webhook_url) per abilitare l'invio. Usa Copia Report nel frattempo."
+    },
+    "copy_report_btn": {
+      "ht": "",
+      "at": "Copia Report"
+    },
+    "reset_btn": {
+      "ht": "",
+      "at": "Reimposta"
+    },
+    "notes_label": {
+      "ht": "",
+      "at": "Feedback aggiuntivo (opzionale):"
+    },
+    "notes_placeholder": {
+      "ht": "",
+      "at": "Descrivi eventuali bug, sorprese o suggerimenti..."
+    },
+    "copied_status": {
+      "ht": "",
+      "at": "Report copiato negli appunti."
+    },
+    "copy_failed_status": {
+      "ht": "",
+      "at": "Impossibile copiare il report negli appunti."
+    },
+    "reset_status": {
+      "ht": "",
+      "at": "Checklist reimpostata."
+    },
+    "no_webhook_status": {
+      "ht": "",
+      "at": "Nessun webhook Discord configurato."
+    },
+    "sending_status": {
+      "ht": "",
+      "at": "Invio del report a Discord in corso..."
     }
   },
   "tutorial": {

--- a/languages/japanese/ui.json
+++ b/languages/japanese/ui.json
@@ -35,6 +35,22 @@
     "defaults_hint": {
       "ht": "",
       "at": "現在の設定（詳細ビューに表示されるものと同じ）を使用します。\n初回実行時は DataForge の抽出に数分かかることがあります。"
+    },
+    "set_game_folder_title": {
+      "ht": "",
+      "at": "ゲームフォルダを設定してください"
+    },
+    "set_game_folder_body": {
+      "ht": "",
+      "at": "変更を適用する前に、Smart Citizen は Star Citizen のインストール場所を知る必要があります。\n\n設定タブでゲームフォルダを設定できるよう、詳細モードに切り替えます。"
+    },
+    "apply_enhancements_confirm_title": {
+      "ht": "",
+      "at": "拡張を適用"
+    },
+    "apply_enhancements_confirm_body": {
+      "ht": "",
+      "at": "現在の設定で最新の拡張機能を生成し、ゲームの global.ini に適用します。まずタイムスタンプ付きのバックアップが作成されます。\n\n初回実行時は DataForge の抽出のため数分かかることがあります。続行しますか？"
     }
   },
   "tabs": {
@@ -69,6 +85,18 @@
     "legal": {
       "ht": "",
       "at": "法的情報"
+    },
+    "about_load_failed": {
+      "ht": "",
+      "at": "アプリ情報を読み込めませんでした。"
+    },
+    "faq_load_failed": {
+      "ht": "",
+      "at": "FAQ を読み込めませんでした。"
+    },
+    "legal_load_failed": {
+      "ht": "",
+      "at": "法的情報を読み込めませんでした。"
     }
   },
   "toolbar": {
@@ -175,6 +203,18 @@
     "apply_disabled_tooltip": {
       "ht": "",
       "at": "すでに適用済みです：前回のゲームへの適用以降、変更はありません。"
+    },
+    "feedback_fallback_text": {
+      "ht": "",
+      "at": "フィードバック・バグ報告・機能投票"
+    },
+    "paypal_fallback_text": {
+      "ht": "",
+      "at": "PayPal で寄付する"
+    },
+    "venmo_fallback_text": {
+      "ht": "",
+      "at": "Venmo"
     }
   },
   "filters": {
@@ -339,6 +379,66 @@
     "column_filter_placeholder": {
       "ht": "",
       "at": "{column} をフィルター…"
+    },
+    "editor_dock_title": {
+      "ht": "",
+      "at": "文字列エディター"
+    },
+    "no_row_selected": {
+      "ht": "",
+      "at": "（行が選択されていません）"
+    },
+    "editor_underline_btn": {
+      "ht": "",
+      "at": "下線"
+    },
+    "editor_highlight_btn": {
+      "ht": "",
+      "at": "ハイライト"
+    },
+    "editor_placeholder": {
+      "ht": "",
+      "at": "文字列エディターの表で行を選択すると、ここでカスタム値を編集できます。"
+    },
+    "context_copy_cell": {
+      "ht": "",
+      "at": "セルをコピー"
+    },
+    "context_copy_key": {
+      "ht": "",
+      "at": "キーをコピー"
+    },
+    "context_edit": {
+      "ht": "",
+      "at": "編集"
+    },
+    "context_reset_to_original": {
+      "ht": "",
+      "at": "元の値に戻す"
+    },
+    "context_copy_all_filtered": {
+      "ht": "",
+      "at": "絞り込み結果をすべてコピー"
+    },
+    "context_remove_favorite": {
+      "ht": "",
+      "at": "★ お気に入りから削除"
+    },
+    "context_add_favorite": {
+      "ht": "",
+      "at": "★ お気に入りに追加"
+    },
+    "showing_count": {
+      "ht": "",
+      "at": "{total} 件中 {shown} 件を表示中"
+    },
+    "copied_key": {
+      "ht": "",
+      "at": "コピーしました：{loc_key}"
+    },
+    "pyperclip_missing": {
+      "ht": "",
+      "at": "pyperclip がインストールされていません"
     }
   },
   "config": {
@@ -661,6 +761,46 @@
     "extract_tooltip": {
       "ht": "",
       "at": "インストール済みの Data.p4k から、標準ローカライズ（base.ini）と DataForge エンティティ XML を展開します。Star Citizen のパッチごとに実行してください。抽出が完了すると、文字列は自動的にテーブルに再読み込みされます。"
+    },
+    "include_new_cb": {
+      "ht": "",
+      "at": "新しく見つかった項目を含める"
+    },
+    "disable_tutorial_cb": {
+      "ht": "",
+      "at": "チュートリアルを無効にする"
+    },
+    "invalid_data_folder_body": {
+      "ht": "",
+      "at": "選択したデータフォルダはディレクトリではなくファイルです：\n{path}"
+    },
+    "onedrive_folder_title": {
+      "ht": "",
+      "at": "データフォルダが OneDrive 内にあります"
+    },
+    "onedrive_folder_body": {
+      "ht": "",
+      "at": "このフォルダは OneDrive 内にあります：\n\n{path}\n\nOneDrive はこれらのファイルを同期し、時には空にしてしまうことがあり、編集内容の消失につながることがあります。OneDrive の外にあるローカルフォルダの使用を強くお勧めします。\n\nこのまま OneDrive フォルダを使用しますか？"
+    },
+    "dataforge_cache_old_new": {
+      "ht": "",
+      "at": "旧：{old}\n新：{new}"
+    },
+    "channel_not_installed_hint": {
+      "ht": "",
+      "at": "⚠ このルート配下に {channel} はインストールされていません — 別のチャンネルを選択してください"
+    },
+    "preview_merge_failed": {
+      "ht": "",
+      "at": "マージのプレビューに失敗しました：{error}"
+    },
+    "game_path_placeholder": {
+      "ht": "",
+      "at": "C:\\Program Files\\Roberts Space Industries\\StarCitizen"
+    },
+    "language_source_placeholder": {
+      "ht": "",
+      "at": "https://…/global.ini"
     }
   },
   "enhancements": {
@@ -923,6 +1063,246 @@
     "extracting_dataforge_tooltip": {
       "ht": "",
       "at": "Data.p4k から DataForge を抽出しています…"
+    },
+    "tag_move_up_tooltip": {
+      "ht": "",
+      "at": "この要素を上に移動"
+    },
+    "tag_move_down_tooltip": {
+      "ht": "",
+      "at": "この要素を下に移動"
+    },
+    "tag_untick_exclude_tooltip": {
+      "ht": "",
+      "at": "チェックを外すとこの要素をタグから除外します"
+    },
+    "tag_edit_mapping_row_btn": {
+      "ht": "",
+      "at": "マッピングを編集…"
+    },
+    "tag_mapping_tooltip_ordinance": {
+      "ht": "",
+      "at": "各追尾タイプに使用する短縮/中間/長い表記を編集します（例：Infrared → I / IR / Infrared）。"
+    },
+    "tag_mapping_tooltip_damage": {
+      "ht": "",
+      "at": "各ダメージタイプに使用する短縮/中間/長い表記を編集します（例：Energy → E / EN / Energy）。"
+    },
+    "tag_mapping_tooltip_type": {
+      "ht": "",
+      "at": "各コンポーネントタイプに使用する短縮/中間/長い表記を編集します（例：Shield Generator → SH / SHLD / Shield）。"
+    },
+    "tag_mapping_tooltip_label": {
+      "ht": "",
+      "at": "クラフティングラベルの短縮/中間/長い表記を編集します（例：Crafting → CF / Craft / Crafting）。"
+    },
+    "tag_mapping_tooltip_collection": {
+      "ht": "",
+      "at": "コレクションラベルの短縮/中間/長い表記を編集します（例：Collection → Col / Collect / Collection）。"
+    },
+    "tag_mapping_tooltip_default": {
+      "ht": "",
+      "at": "各クラスに使用する短縮/中間/長い表記を編集します（例：Military → M / MIL / Military）。"
+    },
+    "mission_detail_fields_heading": {
+      "ht": "",
+      "at": "任務詳細フィールド："
+    },
+    "mission_field_mission_type": {
+      "ht": "",
+      "at": "任務タイプ"
+    },
+    "mission_field_difficulty": {
+      "ht": "",
+      "at": "難易度"
+    },
+    "mission_field_hostiles": {
+      "ht": "",
+      "at": "敵対勢力"
+    },
+    "mission_field_reputation": {
+      "ht": "",
+      "at": "評判"
+    },
+    "mission_field_blueprints": {
+      "ht": "",
+      "at": "設計図"
+    },
+    "mission_field_ace_pilot": {
+      "ht": "",
+      "at": "エースパイロット"
+    },
+    "mission_detail_fields_note": {
+      "ht": "",
+      "at": "チェックを外したフィールドは任務説明から除外されます。次回の「拡張を生成」時に反映されます。"
+    },
+    "stats_prepend_cb": {
+      "ht": "",
+      "at": "説明文の上にステータスを表示"
+    },
+    "standardize_ship_names_cb": {
+      "ht": "",
+      "at": "入手可能な船名を統一表記にする"
+    },
+    "mission_labels_group": {
+      "ht": "",
+      "at": "任務ラベル"
+    },
+    "mission_label_details": {
+      "ht": "",
+      "at": "詳細："
+    },
+    "mission_label_blueprints": {
+      "ht": "",
+      "at": "設計図："
+    },
+    "mission_label_item_rewards": {
+      "ht": "",
+      "at": "アイテム報酬："
+    },
+    "mission_label_blueprint_data": {
+      "ht": "",
+      "at": "設計図データ："
+    },
+    "mission_label_xp": {
+      "ht": "",
+      "at": "経験値ラベル："
+    },
+    "mission_label_header_style": {
+      "ht": "",
+      "at": "見出しスタイル："
+    },
+    "em_label_underline": {
+      "ht": "",
+      "at": "下線"
+    },
+    "em_label_blue_text": {
+      "ht": "",
+      "at": "青色テキスト"
+    },
+    "forge_status_not_extracted": {
+      "ht": "",
+      "at": "DataForge：未抽出 — 「拡張を生成」をクリックして開始してください"
+    },
+    "forge_status_outdated": {
+      "ht": "",
+      "at": "DataForge：キャッシュが古くなっています — 「拡張を生成」をクリックして再抽出・更新してください"
+    },
+    "forge_status_up_to_date": {
+      "ht": "",
+      "at": "DataForge：キャッシュは最新です ✓"
+    },
+    "tag_separator_label": {
+      "ht": "",
+      "at": "区切り文字："
+    },
+    "tag_enclosing_label": {
+      "ht": "",
+      "at": "囲み記号："
+    },
+    "tag_placement_label": {
+      "ht": "",
+      "at": "配置："
+    },
+    "tag_craft_usage_separator_label": {
+      "ht": "",
+      "at": "用途の区切り文字："
+    },
+    "mt_hauling_group": {
+      "ht": "",
+      "at": "輸送任務"
+    },
+    "mt_enable_route_cb": {
+      "ht": "",
+      "at": "輸送任務のタイトルにルートを追加"
+    },
+    "mt_standardize_cb": {
+      "ht": "",
+      "at": "輸送任務名を統一表記にする（例：どの企業でも「Large Shipment」「Haul - Small Scale」ではなく「Medium Cargo Haul」に統一）"
+    },
+    "mt_route_hint": {
+      "ht": "",
+      "at": "任務を受注すると、実際の集荷地点と配達地点がゲーム内で自動的に入力されます。"
+    },
+    "mt_route_arrow_label": {
+      "ht": "",
+      "at": "ルート矢印："
+    },
+    "mt_title_separator_label": {
+      "ht": "",
+      "at": "タイトル区切り文字："
+    },
+    "mt_rank_separator_label": {
+      "ht": "",
+      "at": "ランク区切り文字："
+    },
+    "mt_location_detail_label": {
+      "ht": "",
+      "at": "地点表示の詳細度："
+    },
+    "mt_shorten_titles_cb": {
+      "ht": "",
+      "at": "元のタイトルを短縮する（定型句を短縮します。例：「Local Shipment Route」→「Route」）"
+    },
+    "mt_shorten_sizes_cb": {
+      "ht": "",
+      "at": "貨物サイズを短縮する（貨物のサイズ表記を略します。例：「Extra Small」→「XS」）"
+    },
+    "mt_underline_direct_cb": {
+      "ht": "",
+      "at": "「Direct」に下線を引く（ゲーム内で「Direct」輸送を強調表示します）"
+    },
+    "mt_general_tags_group": {
+      "ht": "",
+      "at": "汎用タグ"
+    },
+    "mt_general_tags_hint": {
+      "ht": "",
+      "at": "これらのタグを任務タイトルにのみ表示・非表示にします"
+    },
+    "mt_tag_rep_cb": {
+      "ht": "",
+      "at": "評判タグ（「[500 REP]」を追加）"
+    },
+    "mt_tag_blueprint_cb": {
+      "ht": "",
+      "at": "設計図タグ（「[BP]」「[BP?]」を追加）"
+    },
+    "mt_tag_ace_cb": {
+      "ht": "",
+      "at": "エースタグ（「[ACE]」「[ACE?]」を追加）"
+    },
+    "mt_tag_rep_track_cb": {
+      "ht": "",
+      "at": "評判トラックタグ（評判タグの後に「(Security)」「(Contractor)」を追加）"
+    },
+    "mt_scanning_group": {
+      "ht": "",
+      "at": "スキャン/採掘任務"
+    },
+    "mt_scanning_hint": {
+      "ht": "",
+      "at": "Recco Battaglia のスキャン/採掘任務は特定の採掘可能な鉱石を対象とし、任務タイトルに各鉱石のリソースシグネチャ値を表示します。"
+    },
+    "mt_tag_rs_cb": {
+      "ht": "",
+      "at": "リソースシグネチャ（RS）タグを表示"
+    },
+    "mt_preview_route_off": {
+      "ht": "",
+      "at": "プレビュー：  {display} [50 REP]  （ルート機能オフ）"
+    },
+    "mt_preview_route_on": {
+      "ht": "",
+      "at": "プレビュー：  {display} [50 REP]"
+    },
+    "tag_preview": {
+      "ht": "",
+      "at": "プレビュー：  {content}"
+    },
+    "tag_preview_no_tag": {
+      "ht": "",
+      "at": "プレビュー：  {name}   （タグなし — すべての要素が空か無効です）"
     }
   },
   "blueprint_tracker": {
@@ -949,6 +1329,10 @@
     "apply_owned_tag_tooltip_disabled": {
       "ht": "",
       "at": "すでに最新です — 前回の適用以降、所有リストは変更されていません。"
+    },
+    "owned_tags_refreshed": {
+      "ht": "",
+      "at": "[Owned] タグを現在の所有リストに合わせて更新しました。"
     }
   },
   "log": {
@@ -1056,7 +1440,7 @@
     },
     "custom_value_prompt": {
       "ht": "",
-      "at": "キーのカスタム値を入力してください：\n{key}"
+      "at": "キーのカスタム値を入力してください：\n{loc_key}"
     },
     "auto_add_summary": {
       "ht": "",
@@ -1431,6 +1815,38 @@
     "skip_generate_tooltip": {
       "ht": "",
       "at": "拡張を生成せずに続行します。後で Enhancements タブから実行できます。"
+    },
+    "crash_error_title": {
+      "ht": "",
+      "at": "Smart Citizen — エラー"
+    },
+    "show_log_btn": {
+      "ht": "",
+      "at": "ログを表示"
+    },
+    "dismiss_btn": {
+      "ht": "",
+      "at": "閉じる"
+    },
+    "suppressed_errors_suffix": {
+      "ht": "",
+      "at": "\n\n（他 {count} 件のエラーが非表示になっています — 詳細はログタブを参照してください）"
+    },
+    "failed_to_delete_global_ini": {
+      "ht": "",
+      "at": "global.ini の削除に失敗しました：{error}"
+    },
+    "failed_to_merge_sources": {
+      "ht": "",
+      "at": "ソースのマージに失敗しました：{error}"
+    },
+    "failed_to_load_sources": {
+      "ht": "",
+      "at": "ソースの読み込みに失敗しました：{error}"
+    },
+    "app_title": {
+      "ht": "",
+      "at": "Smart Citizen"
     }
   },
   "progress": {
@@ -1497,6 +1913,30 @@
     "snapshot_diff": {
       "ht": "",
       "at": "差分用にキャッシュのスナップショットを作成しています…"
+    },
+    "syncing_sources": {
+      "ht": "",
+      "at": "ソースを同期しています..."
+    },
+    "starting_up_title": {
+      "ht": "",
+      "at": "起動中"
+    },
+    "enhancements_label": {
+      "ht": "",
+      "at": "DataForge から拡張ローカライズを生成しています…\n\n初回実行時は数分かかることがあります。"
+    },
+    "generating_enhancements_title": {
+      "ht": "",
+      "at": "拡張を生成中"
+    },
+    "reloading_with_enhancements": {
+      "ht": "",
+      "at": "更新された拡張機能で文字列を再読み込みしています…"
+    },
+    "reloading_after_user_ini_restore": {
+      "ht": "",
+      "at": "user.ini の復元後、{channel} を再読み込みしています..."
     }
   },
   "status_bar": {
@@ -1535,6 +1975,442 @@
     "open_release_page_tooltip": {
       "ht": "",
       "at": "v{version} のリリースページを開く"
+    },
+    "downloading_ini": {
+      "ht": "",
+      "at": "INI ファイルをダウンロード中..."
+    },
+    "starting_up": {
+      "ht": "",
+      "at": "起動中 — ソースを同期しています..."
+    },
+    "generating_enhancements_background": {
+      "ht": "",
+      "at": "バックグラウンドで拡張を生成中…"
+    },
+    "enhancements_generated_applying": {
+      "ht": "",
+      "at": "拡張が生成されました — ゲームに適用中…"
+    },
+    "enhancements_generated_reloading": {
+      "ht": "",
+      "at": "拡張が生成されました — 項目を再読み込み中…"
+    },
+    "enhancement_generation_failed": {
+      "ht": "",
+      "at": "拡張の生成に失敗しました — 詳細はログタブを参照してください"
+    },
+    "user_ini_reset": {
+      "ht": "",
+      "at": "{channel} の user.ini をリセットしました（バックアップ作成済み）"
+    },
+    "user_ini_restored": {
+      "ht": "",
+      "at": "{channel} の user.ini を復元しました"
+    },
+    "channel_indicator": {
+      "ht": "",
+      "at": "チャンネル：{channel}"
+    },
+    "channel_switched_extracting": {
+      "ht": "",
+      "at": "{channel} に切り替えました — Data.p4k を抽出中…"
+    },
+    "channel_switched_reloading": {
+      "ht": "",
+      "at": "{channel} に切り替えました — ソースを再読み込み中…"
+    },
+    "data_folder_changed_extracting": {
+      "ht": "",
+      "at": "データフォルダが {data_dir} に変更されました — Data.p4k を抽出中…"
+    },
+    "data_folder_changed_reloading": {
+      "ht": "",
+      "at": "データフォルダが {data_dir} に変更されました — ソースを再読み込み中…"
+    },
+    "cache_folder_changed": {
+      "ht": "",
+      "at": "DataForge キャッシュフォルダが変更されました — Data.p4k から再抽出中…"
+    },
+    "syncing_source": {
+      "ht": "",
+      "at": "{source_name} を同期中..."
+    },
+    "source_updated": {
+      "ht": "",
+      "at": "更新済み ↑"
+    },
+    "source_offline": {
+      "ht": "",
+      "at": "（オフライン？）"
+    },
+    "entry_count": {
+      "ht": "",
+      "at": "{count} 件"
+    },
+    "override_count_suffix": {
+      "ht": "",
+      "at": " | {count} 件の上書き"
+    },
+    "manifest_missing": {
+      "ht": "",
+      "at": "SC {channel}（マニフェストがありません）"
+    }
+  },
+  "import_flow": {
+    "source_dialog_title": {
+      "ht": "",
+      "at": "INI ファイルをインポート"
+    },
+    "source_dialog_label": {
+      "ht": "",
+      "at": "ローカルファイルパスまたは URL を入力してください："
+    },
+    "source_dialog_placeholder": {
+      "ht": "",
+      "at": "C:\\path\\to\\file.ini または https://example.com/file.ini"
+    },
+    "browse_btn": {
+      "ht": "",
+      "at": "参照..."
+    },
+    "select_ini_file_title": {
+      "ht": "",
+      "at": "INI ファイルを選択"
+    },
+    "ini_file_filter": {
+      "ht": "",
+      "at": "INI ファイル (*.ini);;すべてのファイル (*)"
+    },
+    "download_error_title": {
+      "ht": "",
+      "at": "ダウンロードエラー"
+    },
+    "download_error_body": {
+      "ht": "",
+      "at": "ダウンロードに失敗しました：\n{source}\n\n{error}"
+    },
+    "no_base_data_title": {
+      "ht": "",
+      "at": "ベースデータがありません"
+    },
+    "no_base_data_body": {
+      "ht": "",
+      "at": "ベース INI がまだ読み込まれていません。先に Data.p4k から抽出してください。"
+    },
+    "no_valid_keys_title": {
+      "ht": "",
+      "at": "有効なキーがありません"
+    },
+    "no_valid_keys_body": {
+      "ht": "",
+      "at": "インポートされた {count} 件のキーのうち、base.ini に存在するものはありませんでした。\nすべてのキーが除外されました。"
+    },
+    "nothing_to_import_title": {
+      "ht": "",
+      "at": "インポートするものがありません"
+    },
+    "nothing_to_import_body": {
+      "ht": "",
+      "at": "インポートされたキーはすべて、同じ値で user.ini に既に存在しています。"
+    },
+    "confirm_title": {
+      "ht": "",
+      "at": "INI をインポート"
+    },
+    "confirm_body": {
+      "ht": "",
+      "at": "{new_count} 件の新しいキーが user.ini に追加されます。\n{excluded_count} 件のキーが除外されます（base.ini に存在しません）。\n\n続行しますか？"
+    },
+    "reload_status": {
+      "ht": "",
+      "at": "インポートされたデータで再読み込み中..."
+    },
+    "complete_title": {
+      "ht": "",
+      "at": "インポート完了"
+    },
+    "complete_body": {
+      "ht": "",
+      "at": "インポートに成功しました。\n\n  追加：{added} 件のキー\n  競合解決：{resolved} 件のキー\n  除外：{excluded} 件のキー"
+    },
+    "error_title": {
+      "ht": "",
+      "at": "インポートエラー"
+    },
+    "error_body": {
+      "ht": "",
+      "at": "INI ファイルのインポートに失敗しました：\n{error}"
+    }
+  },
+  "restore_backup": {
+    "select_file_title": {
+      "ht": "",
+      "at": "復元するバックアップファイルを選択"
+    },
+    "file_filter": {
+      "ht": "",
+      "at": "バックアップファイル (*.bak_*);;INI ファイル (*.ini);;すべてのファイル (*)"
+    },
+    "success_body": {
+      "ht": "",
+      "at": "次のバックアップから復元しました：\n{name}"
+    },
+    "error_body": {
+      "ht": "",
+      "at": "バックアップの復元に失敗しました：{error}"
+    }
+  },
+  "onedrive": {
+    "warning_title": {
+      "ht": "",
+      "at": "Smart Citizen のデータが OneDrive 内にあります"
+    },
+    "warning_body": {
+      "ht": "",
+      "at": "Smart Citizen は編集内容（user.ini）、ソースキャッシュ、バックアップを次の場所に保存しています：\n\n{data_dir}\n\nこのフォルダは OneDrive 内にあります。OneDrive はこれらのファイルを同期し、時には空にしてしまうことがあり、編集内容の消失につながることがあります。OneDrive の外にあるローカルフォルダにデータを移動すればこの問題を回避できます。\n\n次の場所に移動しますか：\n{local} ？"
+    },
+    "move_btn": {
+      "ht": "",
+      "at": "ローカルフォルダに移動"
+    },
+    "keep_here_btn": {
+      "ht": "",
+      "at": "このままにする"
+    },
+    "dont_warn_again": {
+      "ht": "",
+      "at": "今後表示しない"
+    }
+  },
+  "user_ini_reset": {
+    "backup_note": {
+      "ht": "",
+      "at": "\n\nバックアップの保存先：\n{path}"
+    },
+    "complete_title": {
+      "ht": "",
+      "at": "user.ini をリセットしました"
+    },
+    "complete_body": {
+      "ht": "",
+      "at": "{channel} チャンネルのカスタム上書き設定はすべて消去されました。{backup_note}"
+    }
+  },
+  "restore_user_ini": {
+    "no_snapshots_title": {
+      "ht": "",
+      "at": "スナップショットがまだありません"
+    },
+    "no_snapshots_body": {
+      "ht": "",
+      "at": "Smart Citizen には {channel} チャンネルの自動 user.ini スナップショットがまだありません。スナップショットは上書き設定が変更されるたびに保存されるため、編集を行って保存した後に復元ポイントが表示されます。"
+    },
+    "snapshot_label": {
+      "ht": "",
+      "at": "{when}  —  {lines} 件の上書き、{size_kb} KB"
+    },
+    "picker_title": {
+      "ht": "",
+      "at": "user.ini を復元"
+    },
+    "picker_label": {
+      "ht": "",
+      "at": "{channel} チャンネルで復元するスナップショットを選んでください。\n現在の user.ini はまず先にスナップショットとして保存されるため、この操作は元に戻せます。"
+    },
+    "restore_failed_title": {
+      "ht": "",
+      "at": "復元に失敗しました"
+    },
+    "restore_failed_body": {
+      "ht": "",
+      "at": "Smart Citizen はスナップショットを復元できませんでした：\n\n{error_type}：{error}"
+    },
+    "restored_title": {
+      "ht": "",
+      "at": "user.ini を復元しました"
+    },
+    "restored_body": {
+      "ht": "",
+      "at": "{channel} チャンネルの上書き設定を次から復元しました：\n{name}\n\n復元した上書き設定をゲームに反映するには「拡張を適用」を実行してください。"
+    }
+  },
+  "extract": {
+    "path_required_title": {
+      "ht": "",
+      "at": "Star Citizen のパスが必要です"
+    },
+    "path_required_body": {
+      "ht": "",
+      "at": "Star Citizen のインストールパスが設定されておらず、キャッシュされたローカライズデータも見つかりませんでした。\n\n設定タブで Star Citizen のインストールパスを設定してから、「抽出」をクリックしてゲームのローカライズ文字列を読み込んでください。"
+    },
+    "p4k_prompt_title": {
+      "ht": "",
+      "at": "Data.p4k から抽出"
+    },
+    "p4k_prompt_base_missing": {
+      "ht": "",
+      "at": "キャッシュにベースローカライズファイルが見つかりません。\n\n今すぐ Data.p4k から global.ini を抽出しますか？\n（ローカライズ文字列を読み込んで表示するために必要です。）"
+    },
+    "p4k_prompt_p4k_newer": {
+      "ht": "",
+      "at": "Data.p4k がキャッシュされた base.ini より新しくなっています。\n\n今すぐ Data.p4k から global.ini を抽出しますか？\n（現在インストールされているゲームバージョンに正確に一致する標準文字列が得られます。）"
+    },
+    "dataforge_outdated_title": {
+      "ht": "",
+      "at": "DataForge キャッシュが古くなっています"
+    },
+    "dataforge_outdated_body": {
+      "ht": "",
+      "at": "DataForge のエンティティキャッシュが現在の Data.p4k より古くなっています。\n\n今すぐ DataForge を再抽出して拡張を再生成しますか？\n\nこれには数分かかり、バックグラウンドで実行されます — 処理中も文字列の編集を続けられます。待ちたくない場合は今は飛ばしても構いません。後で拡張タブからいつでも実行できます。"
+    },
+    "generate_dialog_title": {
+      "ht": "",
+      "at": "拡張を生成"
+    },
+    "category_singular": {
+      "ht": "",
+      "at": "つの拡張カテゴリが不足しています。"
+    },
+    "category_plural": {
+      "ht": "",
+      "at": "つの拡張カテゴリが不足しています。"
+    },
+    "missing_categories_body": {
+      "ht": "",
+      "at": "{count}{noun}\n生成するものを選択してください。\nこれは後で拡張タブから変更できます。"
+    },
+    "missing_category_label": {
+      "ht": "",
+      "at": "{label}  （不足）"
+    },
+    "dataforge_auto_extract_note": {
+      "ht": "",
+      "at": "DataForge データはまだキャッシュされていない場合、自動的に抽出されます。\n初回実行には数分かかります。"
+    },
+    "generate_btn": {
+      "ht": "",
+      "at": "生成"
+    },
+    "skip_btn": {
+      "ht": "",
+      "at": "スキップ"
+    },
+    "dataforge_extracting_background": {
+      "ht": "",
+      "at": "バックグラウンドで DataForge を抽出中 — これには数分かかります…"
+    },
+    "dataforge_extracting_label": {
+      "ht": "",
+      "at": "Data.p4k から DataForge を抽出中 — これには数分かかります…"
+    },
+    "dataforge_extraction_title": {
+      "ht": "",
+      "at": "DataForge 抽出"
+    },
+    "dataforge_extraction_error_title": {
+      "ht": "",
+      "at": "DataForge 抽出エラー"
+    },
+    "dataforge_extraction_error_body": {
+      "ht": "",
+      "at": "DataForge の抽出に失敗しました：\n\n{message}\n\n詳細はログタブを参照してください。"
+    },
+    "dataforge_extracted_generating": {
+      "ht": "",
+      "at": "DataForge を抽出しました — 拡張を生成中…"
+    },
+    "dataforge_extraction_failed": {
+      "ht": "",
+      "at": "DataForge の抽出に失敗しました — 詳細はログタブを参照してください"
+    },
+    "p4k_extracting_label": {
+      "ht": "",
+      "at": "Data.p4k から global.ini を抽出中..."
+    },
+    "p4k_extraction_title": {
+      "ht": "",
+      "at": "P4K 抽出"
+    },
+    "extraction_error_title": {
+      "ht": "",
+      "at": "抽出エラー"
+    }
+  },
+  "apply": {
+    "cannot_save_edits_title": {
+      "ht": "",
+      "at": "編集内容を保存できません"
+    },
+    "cannot_save_edits_body": {
+      "ht": "",
+      "at": "Smart Citizen は編集内容を次の場所に書き込めませんでした：\n\n  {path}\n\n{error_type}：{error}\n\nゲームファイルは変更されていません。よくある原因：\n  • アンチウイルスソフトや Windows のコントロールされたフォルダーアクセスがゲームフォルダへの書き込みをブロックしている\n  • user.ini ファイルが別のプログラムで開かれている\n  • ドライブが読み取り専用か、空き容量が不足している\n\n根本的な問題を解決してから、もう一度適用してください。"
+    },
+    "applied_body": {
+      "ht": "",
+      "at": "{target_path} に適用しました\n\n  ユーザー編集数：{user_count}\n\n{enhancement_block}"
+    },
+    "failed_body": {
+      "ht": "",
+      "at": "ゲームへの適用に失敗しました：{error}"
+    }
+  },
+  "test_plan": {
+    "intro": {
+      "ht": "",
+      "at": "このビルドの各項目を確認し、確認できたらチェックを入れてください。進捗は自動的に保存されます。完了したら、「レポートをコピー」または「送信」で見つけた内容を共有してください。"
+    },
+    "tester_label": {
+      "ht": "",
+      "at": "テスター："
+    },
+    "tester_placeholder": {
+      "ht": "",
+      "at": "あなたの名前またはハンドルネーム"
+    },
+    "submit_btn": {
+      "ht": "",
+      "at": "Discord に送信"
+    },
+    "no_webhook_tooltip": {
+      "ht": "",
+      "at": "Discord の Webhook が設定されていません。送信を有効にするには {env_var} 環境変数（または test_plan/webhook_url 設定）を設定してください。それまでは「レポートをコピー」をご利用ください。"
+    },
+    "copy_report_btn": {
+      "ht": "",
+      "at": "レポートをコピー"
+    },
+    "reset_btn": {
+      "ht": "",
+      "at": "リセット"
+    },
+    "notes_label": {
+      "ht": "",
+      "at": "追加のフィードバック（任意）："
+    },
+    "notes_placeholder": {
+      "ht": "",
+      "at": "バグ、想定外の挙動、提案などを記入してください..."
+    },
+    "copied_status": {
+      "ht": "",
+      "at": "レポートをクリップボードにコピーしました。"
+    },
+    "copy_failed_status": {
+      "ht": "",
+      "at": "レポートをクリップボードにコピーできませんでした。"
+    },
+    "reset_status": {
+      "ht": "",
+      "at": "チェックリストをリセットしました。"
+    },
+    "no_webhook_status": {
+      "ht": "",
+      "at": "Discord の Webhook が設定されていません。"
+    },
+    "sending_status": {
+      "ht": "",
+      "at": "Discord にレポートを送信中..."
     }
   },
   "tutorial": {

--- a/tests/test_chinese_activation.py
+++ b/tests/test_chinese_activation.py
@@ -86,6 +86,17 @@ def test_chinese_covers_full_english_key_universe():
     assert not extra, f"Chinese has keys English on this branch doesn't have: {extra[:10]}"
 
 
+# dialogs.suppressed_errors_suffix's {plural} is deliberately dropped: the
+# token is only ever filled with a hardcoded English "s" suffix
+# (main_window.py), which has no equivalent in Chinese -- there's no suffix
+# pluralization to append it to. German drops the same token for the
+# analogous reason (its "Fehler" is already invariant); str.format ignores
+# unused kwargs, so a dropped placeholder in the string is harmless.
+_ALLOWED_PLACEHOLDER_DROPS = {
+    "dialogs.suppressed_errors_suffix": {"{plural}"},
+}
+
+
 def test_chinese_placeholders_match_english_source():
     en = {p: leaf for p, leaf in _leaves(json.loads(_EN_UI.read_text(encoding="utf-8")))}
     cn = {p: leaf for p, leaf in _leaves(json.loads(_CN_UI.read_text(encoding="utf-8")))}
@@ -95,7 +106,8 @@ def test_chinese_placeholders_match_english_source():
             continue
         en_tokens = set(_PLACEHOLDER.findall(en_leaf.get("ht", "")))
         cn_tokens = set(_PLACEHOLDER.findall(cn[path].get("at", "")))
-        if en_tokens != cn_tokens:
+        allowed_drop = _ALLOWED_PLACEHOLDER_DROPS.get(path, set())
+        if en_tokens - cn_tokens != allowed_drop or cn_tokens - en_tokens:
             mismatches.append((path, sorted(en_tokens), sorted(cn_tokens)))
     assert not mismatches, f"placeholder drift: {mismatches[:5]}"
 

--- a/tests/test_italian_activation.py
+++ b/tests/test_italian_activation.py
@@ -85,6 +85,18 @@ def test_italian_covers_full_english_key_universe():
     assert not extra, f"Italian has keys English on this branch doesn't have: {extra[:10]}"
 
 
+# dialogs.suppressed_errors_suffix's {plural} is deliberately dropped: the
+# token is only ever filled with a hardcoded English "s" suffix
+# (main_window.py). Italian pluralizes with a stem change (errore ->
+# errori), not a suffix append, so the token has no correct value to hold
+# either way. German drops the same token for the analogous reason;
+# str.format ignores unused kwargs, so a dropped placeholder in the string
+# is harmless.
+_ALLOWED_PLACEHOLDER_DROPS = {
+    "dialogs.suppressed_errors_suffix": {"{plural}"},
+}
+
+
 def test_italian_placeholders_match_english_source():
     en = {p: leaf for p, leaf in _leaves(json.loads(_EN_UI.read_text(encoding="utf-8")))}
     it = {p: leaf for p, leaf in _leaves(json.loads(_IT_UI.read_text(encoding="utf-8")))}
@@ -94,7 +106,8 @@ def test_italian_placeholders_match_english_source():
             continue
         en_tokens = set(_PLACEHOLDER.findall(en_leaf.get("ht", "")))
         it_tokens = set(_PLACEHOLDER.findall(it[path].get("at", "")))
-        if en_tokens != it_tokens:
+        allowed_drop = _ALLOWED_PLACEHOLDER_DROPS.get(path, set())
+        if en_tokens - it_tokens != allowed_drop or it_tokens - en_tokens:
             mismatches.append((path, sorted(en_tokens), sorted(it_tokens)))
     assert not mismatches, f"placeholder drift: {mismatches[:5]}"
 

--- a/tests/test_japanese_activation.py
+++ b/tests/test_japanese_activation.py
@@ -72,6 +72,18 @@ def test_japanese_is_ai_only_every_leaf_at_filled_ht_empty():
     assert len(leaves) > 300
 
 
+# dialogs.suppressed_errors_suffix's {plural} is deliberately dropped: the
+# token is only ever filled with a hardcoded English "s" suffix
+# (main_window.py), which has no equivalent in Japanese -- nouns don't
+# inflect for number, so there's no suffix pluralization to append it to.
+# German drops the same token for the analogous reason (its "Fehler" is
+# already invariant); str.format ignores unused kwargs, so a dropped
+# placeholder in the string is harmless.
+_ALLOWED_PLACEHOLDER_DROPS = {
+    "dialogs.suppressed_errors_suffix": {"{plural}"},
+}
+
+
 def test_japanese_placeholders_match_english_source():
     en = {p: leaf for p, leaf in _leaves(json.loads(_EN_UI.read_text(encoding="utf-8")))}
     ja = {p: leaf for p, leaf in _leaves(json.loads(_JA_UI.read_text(encoding="utf-8")))}
@@ -81,7 +93,8 @@ def test_japanese_placeholders_match_english_source():
             continue
         en_tokens = set(_PLACEHOLDER.findall(en_leaf.get("ht", "")))
         ja_tokens = set(_PLACEHOLDER.findall(ja[path].get("at", "")))
-        if en_tokens != ja_tokens:
+        allowed_drop = _ALLOWED_PLACEHOLDER_DROPS.get(path, set())
+        if en_tokens - ja_tokens != allowed_drop or ja_tokens - en_tokens:
             mismatches.append((path, sorted(en_tokens), sorted(ja_tokens)))
     assert not mismatches, f"placeholder drift: {mismatches[:5]}"
 


### PR DESCRIPTION
## Summary
- Closes #318.
- Each of the four new-language PRs is individually self-consistent on its own branch, but those branches were cut before #268, #308, #311 and others added new English UI keys. Once merged, each language ends up 215 keys short of English's key universe, and each language's own `test_*_activation.py` asserts full coverage with every leaf `at`-filled -- so the merged result fails tests that no individual PR fails.
- German already got this treatment during its own PR's rebase (#313, not yet merged as of this PR). This backfills the three languages already merged onto `release/2.3.0`: Chinese, Italian, Japanese.
- Backfilled 215 keys per language (645 strings total) styled on each file's existing terminology, with placeholders, leading/trailing whitespace, and untranslated literals (`user.ini`, `Data.p4k`, `DataForge`, `LIVE`/`PTU`/`EPTU`/`HOTFIX`, `[Owned]`, `[BP]`) preserved.
- Fixed the second post-merge landmine #318 flagged: `import_dialog.custom_value_prompt`'s `{key}` placeholder was renamed to `{loc_key}` on `release/2.2.1` and reached 2.3.0 via #289, but all three languages still carried the old `{key}` -- not wrong on their own branches (English said `{key}` there too), but a live `KeyError` once merged, since `import_dialog.py` calls `tr(..., loc_key=key)`. Fixed all three to `{loc_key}`.
- Fixed the `{plural}` inconsistency #318 flagged: `dialogs.suppressed_errors_suffix`'s `{plural}` token is only ever filled with a hardcoded English "s" suffix (`main_window.py`), which has no correct value in Chinese, Italian, or Japanese. German already drops this token via an `_ALLOWED_PLACEHOLDER_DROPS` allowance; added the same allowance to the other three languages' activation tests and dropped the token from their translations, matching `TRANSLATIONS.md`'s documented policy.

## Testing Checklist
- [x] PR is scoped to one concern (post-merge i18n backfill for 3 languages, no app code changed)
- [x] `pytest tests/` passes locally (1335 passed, 0 failed, 21 skipped -- the 5 pre-existing failures this backfill targets are gone)
- [x] Portable built and tester-confirmed working
- [x] Target branch is the active `release/2.3.0`, not `main`

## Testing performed
Ran the full test suite before and after (5 failed -> 0 failed). Built a portable merging this alongside the other in-flight fixes and had it tester-confirmed working before opening this PR.

---
🤖 PR description generated with [Claude Code](https://claude.com/claude-code)
