### PR TITLE
Fix raw blueprint-filename bullets not resolving to display names

### DIFF
--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -88,6 +88,23 @@ except ImportError:  # pragma: no cover — only triggers if src/ is removed
     def win_long_path(path):  # type: ignore[misc]
         return str(path)
 
+# Same deferred-import pattern again. blueprint_meta.py's Blueprint Tracker
+# needs this exact same bp_craft_/bp_rewards_/bp_ prefix-strip when a raw
+# blueprint filename shows up verbatim in mission text; sharing it here
+# instead of a second hand-maintained copy means the two can't drift out of
+# sync on which prefixes are known.
+try:
+    _gen_root = Path(__file__).parent.parent
+    if str(_gen_root) not in sys.path:
+        sys.path.insert(0, str(_gen_root))
+    from src.utils.blueprint_meta import strip_raw_blueprint_filename_prefix
+except ImportError:  # pragma: no cover — only triggers if src/ is removed
+    def strip_raw_blueprint_filename_prefix(stem):  # type: ignore[misc]
+        for prefix in ("bp_craft_", "bp_rewards_", "bp_"):
+            if stem.lower().startswith(prefix):
+                return stem[len(prefix):], True
+        return stem, False
+
 
 # ── Paths ─────────────────────────────────────────────────────────────────────
 
@@ -3032,13 +3049,7 @@ def _name_from_blueprint_filename(bp_xml: Path) -> str:
         bp_rewards_eckhartsecuritykillnpcboss.xml
             → "Eckhartsecuritykillnpcboss"
     """
-    stem = bp_xml.stem
-    # Strip common prefixes — bp_craft_, bp_rewards_, bp_ — so the
-    # surfaced part is the descriptive tail.
-    for prefix in ("bp_craft_", "bp_rewards_", "bp_"):
-        if stem.startswith(prefix):
-            stem = stem[len(prefix):]
-            break
+    stem, _matched = strip_raw_blueprint_filename_prefix(bp_xml.stem)
     # Replace separators with spaces and title-case.
     fallback = stem.replace("_", " ").replace("-", " ").title()
     return _BLUEPRINT_FILENAME_FALLBACK_ALIASES.get(fallback, fallback)

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -233,9 +233,29 @@ _BULLET_NAME_ALIASES: dict[str, str] = {
 }
 
 # Prefixes CIG strips off a blueprint XML's filename before the descriptive
-# part (mirrors generate_enhancements_ini.py's _name_from_blueprint_filename,
-# which uses this same transform when resolving a blueprint pool entry).
-_RAW_BLUEPRINT_FILENAME_PREFIXES = ("bp_craft_", "bp_rewards_", "bp_")
+# part. Shared with generate_enhancements_ini.py's _name_from_blueprint_filename
+# (imported from here, same deferred-import pattern as tag_builder/win_paths)
+# so the two don't hand-maintain separate copies of the same transform.
+RAW_BLUEPRINT_FILENAME_PREFIXES = ("bp_craft_", "bp_rewards_", "bp_")
+
+
+def strip_raw_blueprint_filename_prefix(stem: str) -> "tuple[str, bool]":
+    """Strip a known bp_* filename prefix (case-insensitively) from *stem*.
+
+    Returns ``(remainder, True)`` if a prefix matched, or ``(stem, False)``
+    unchanged if it didn't -- deliberately leaves "no prefix matched" for the
+    caller to interpret, since the two current callers disagree on what that
+    means: :func:`_raw_blueprint_filename_slug` below takes it as "this bullet
+    isn't shaped like a raw blueprint filename at all," while
+    generate_enhancements_ini.py's ``_name_from_blueprint_filename`` still
+    transforms the untouched stem (its caller already knows it's a genuine
+    blueprint XML path, so there's no "is this one at all" question to ask).
+    """
+    lowered = stem.lower()
+    for prefix in RAW_BLUEPRINT_FILENAME_PREFIXES:
+        if lowered.startswith(prefix):
+            return stem[len(prefix):], True
+    return stem, False
 
 
 def _raw_blueprint_filename_slug(raw_nm: str) -> "str | None":
@@ -254,12 +274,10 @@ def _raw_blueprint_filename_slug(raw_nm: str) -> "str | None":
     same title-cased string for the fuel-nozzle family), so no new aliases
     are needed, just the extra normalization step to reach them.
     """
-    lowered = raw_nm.lower()
-    for prefix in _RAW_BLUEPRINT_FILENAME_PREFIXES:
-        if lowered.startswith(prefix):
-            stem = raw_nm[len(prefix):]
-            return stem.replace("_", " ").replace("-", " ").title()
-    return None
+    stem, matched = strip_raw_blueprint_filename_prefix(raw_nm)
+    if not matched:
+        return None
+    return stem.replace("_", " ").replace("-", " ").title()
 
 
 # Fuel nozzle Name-key conventions (#266 follow-up): nozzles ship under two

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -232,6 +232,36 @@ _BULLET_NAME_ALIASES: dict[str, str] = {
     "Nozzle Fuelgiver Misc Nozzlestandard": "RN-7s",
 }
 
+# Prefixes CIG strips off a blueprint XML's filename before the descriptive
+# part (mirrors generate_enhancements_ini.py's _name_from_blueprint_filename,
+# which uses this same transform when resolving a blueprint pool entry).
+_RAW_BLUEPRINT_FILENAME_PREFIXES = ("bp_craft_", "bp_rewards_", "bp_")
+
+
+def _raw_blueprint_filename_slug(raw_nm: str) -> "str | None":
+    """Recover a real display name from a raw blueprint-XML-filename-shaped
+    bullet, or None if *raw_nm* doesn't look like one.
+
+    Some mission text ships the raw blueprint filename stem verbatim instead
+    of a resolved display name -- confirmed via a live "URGENT REFUEL
+    REQUEST" mission body listing "bp_craft_nozzle_fuelgiver_grin_
+    nozzleverysecure" for what should be "Harkin". This is a different root
+    cause than _key_slug's garbled-KEY bug above: the bullet here is the
+    blueprint's own filename, not a de-slugified loc key, so it needs its
+    own prefix-strip + title-case transform before _BULLET_NAME_ALIASES can
+    recognize it -- once transformed it lands on the exact same alias-table
+    entries the key-slug bug already uses (both bugs happen to produce the
+    same title-cased string for the fuel-nozzle family), so no new aliases
+    are needed, just the extra normalization step to reach them.
+    """
+    lowered = raw_nm.lower()
+    for prefix in _RAW_BLUEPRINT_FILENAME_PREFIXES:
+        if lowered.startswith(prefix):
+            stem = raw_nm[len(prefix):]
+            return stem.replace("_", " ").replace("-", " ").title()
+    return None
+
+
 # Fuel nozzle Name-key conventions (#266 follow-up): nozzles ship under two
 # different manufacturer-specific prefixes (MISC's item_fuelnozzle_* vs
 # Greycat/Shubin's Nozzle_FuelGiver_*), neither matching the item_Name /
@@ -474,16 +504,23 @@ def build_blueprint_metadata(entries) -> dict:
     # Pass 2: gather each blueprint item's missions, then attach type + attrs.
     # A bullet name that doesn't match any real item directly is checked
     # against the known one-off aliases, then against the key-slug fallback
-    # (see _BULLET_NAME_ALIASES / _key_slug) before falling back to itself —
-    # so a mismatched bullet still joins the real, tagged item instead of
-    # creating a separate untagged "Other" entry.
+    # (see _BULLET_NAME_ALIASES / _key_slug), then against the raw-filename
+    # fallback (see _raw_blueprint_filename_slug) before falling back to
+    # itself, so a mismatched bullet still joins the real, tagged item
+    # instead of creating a separate untagged "Other" entry.
     missions_by_name: dict = {}
     for pair, val in bp_descs:
         title = titles.get(pair) if pair else None
         for raw_nm in extract_bp_item_names(val):
-            nm = raw_nm if raw_nm in name_to_value else (
-                _BULLET_NAME_ALIASES.get(raw_nm) or keyslug_to_name.get(raw_nm, raw_nm)
-            )
+            if raw_nm in name_to_value:
+                nm = raw_nm
+            elif raw_nm in _BULLET_NAME_ALIASES:
+                nm = _BULLET_NAME_ALIASES[raw_nm]
+            elif raw_nm in keyslug_to_name:
+                nm = keyslug_to_name[raw_nm]
+            else:
+                slug = _raw_blueprint_filename_slug(raw_nm)
+                nm = _BULLET_NAME_ALIASES.get(slug, raw_nm) if slug else raw_nm
             bucket = missions_by_name.setdefault(nm, set())
             if title:
                 bucket.add(title)

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -481,6 +481,38 @@ class TestBulletNameMismatches:
         assert "Nozzle Fuelgiver Grin Nozzleverysecure" not in meta
         assert "Nozzle Fuelgiver Misc Nozzlestandard" not in meta
 
+    @pytest.mark.regression
+    def test_raw_blueprint_filename_bullet_resolves_via_alias(self):
+        """A different root cause than the key-slug bug above: some mission
+        text ships the raw blueprint XML filename stem verbatim rather than
+        a de-slugified loc key. Confirmed via the real "URGENT REFUEL
+        REQUEST" (UWC_Refueling_*) mission bodies in
+        tests/fixtures/kraken_global_latest.ini, which list
+        "bp_craft_nozzle_fuelgiver_grin_nozzleverysecure" (lowercase, with
+        the bp_craft_ prefix, plus the "(Fuel Nozzle)" category annotation)
+        instead of "Harkin" -- a shape _key_slug's title-cased-KEY transform
+        never produces, so it silently fell through to itself even though
+        the alias table already had the right answer."""
+        desc = (
+            "x\\n<EM4>POTENTIAL BLUEPRINTS</EM4>"
+            "\\n- bp_craft_nozzle_fuelgiver_grin_nozzlefast (Fuel Nozzle)"
+            "\\n- bp_craft_nozzle_fuelgiver_grin_nozzleverysecure (Fuel Nozzle)"
+            "\\n- bp_craft_nozzle_fuelgiver_misc_nozzlestandard (Fuel Nozzle)"
+        )
+        entries = [
+            _Entry("M_Desc_001", desc, "Missions"),
+            _Entry("item_fuelnozzle_GRIN_Fast_Name", "Norfield", "Ship Items"),
+            _Entry("item_fuelnozzle_GRIN_Safe_Name", "Harkin", "Ship Items"),
+            _Entry("item_fuelnozzle_MISC_Standard_Name", "RN-7s", "Ship Items"),
+        ]
+        meta = build_blueprint_metadata(entries)
+        assert meta["Norfield"].tagged_name == "Norfield"
+        assert meta["Harkin"].tagged_name == "Harkin"
+        assert meta["RN-7s"].tagged_name == "RN-7s"
+        assert "bp_craft_nozzle_fuelgiver_grin_nozzlefast" not in meta
+        assert "bp_craft_nozzle_fuelgiver_grin_nozzleverysecure" not in meta
+        assert "bp_craft_nozzle_fuelgiver_misc_nozzlestandard" not in meta
+
     def test_direct_match_is_not_overridden_by_alias_or_keyslug(self):
         """A bullet name that already matches a real item directly must
         win outright -- the alias/keyslug fallback only kicks in when the


### PR DESCRIPTION
## Problem

Some mission text (CIG's own `UWC_Refueling` bodies) ships the raw blueprint XML filename stem verbatim in a POTENTIAL BLUEPRINTS bullet, e.g.:

```
bp_craft_nozzle_fuelgiver_grin_nozzleverysecure
```

instead of a resolved display name. The Blueprint Tracker then lists that raw string as its own item, so the real item ("Harkin") never gets an `[Owned]` tag from that bullet.

This is a different shape than the existing `_key_slug` garbled-KEY bug, so it never matched `_BULLET_NAME_ALIASES` even though the alias table already had the right answer.

## Fix

Adds `_raw_blueprint_filename_slug()`, which mirrors the prefix-strip + title-case transform `scripts/generate_enhancements_ini.py`'s `_name_from_blueprint_filename` already performs, then re-checks `_BULLET_NAME_ALIASES`. It runs as a fallback in the existing bullet-resolution chain, only after the current alias and `_key_slug` attempts have both failed, so no bullet that resolves correctly today changes behaviour.

Prefixes handled: `bp_craft_`, `bp_rewards_`, `bp_`.

## Testing

Confirmed against the real `UWC_Refueling` mission body in `tests/fixtures/kraken_global_latest.ini`. Full suite passes (1338 passed, 21 skipped).

Found while investigating SCMDB blueprint import/export feasibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)