### PR TITLE
i18n: fix FR/ES/PT settings-backup strings from #311

### DIFF
--- a/languages/TRANSLATIONS.md
+++ b/languages/TRANSLATIONS.md
@@ -50,6 +50,15 @@ them against the new source.
 
 ## Backfill log
 
+- **2.3.0 cycle (2026-08-01, Claude Fable 5):** Corrected the french, spanish,
+  and portuguese_br AI strings for the #311 Settings Backup feature (the
+  `settings_backup.*` and `config.backup*`/`config.*_settings_*` keys). Two
+  fixes: the import-confirm dialog pointed users at the Reset user.ini button
+  ("Réinitialiser"/"Restablecer"/"Redefinir") where English references
+  Restore user.ini (now "Restaurer"/"Restaurar"/"Restaurar", matching each
+  file's own `config.restore_user_ini_btn`), and the whole key set shipped
+  without diacritics ("parametres", "configuracoes"), inconsistent with the
+  rest of those files. All corrected strings stay `at`-only, `ht: ""`.
 - **2.2.1 pre-release (2026-07-18, Claude Fable 5):** AI backfill of the 215
   keys the #247 hardcoded-string sweep added in English only (Tag Builder
   tooltips and labels, Mission Titles page, mission detail fields, the Import

--- a/languages/french/ui.json
+++ b/languages/french/ui.json
@@ -812,27 +812,27 @@
     },
     "backup_group": {
       "ht": "",
-      "at": "Sauvegarde des parametres"
+      "at": "Sauvegarde des paramètres"
     },
     "backup_desc": {
       "ht": "",
-      "at": "Enregistrez tous vos parametres (preferences, configurations d'etiquettes, votre dossier Star Citizen et vos modifications de texte personnalisees pour chaque canal) dans un seul petit fichier de sauvegarde. Importez-le sur un nouveau PC, apres une extraction portable fraiche, ou pour annuler une mauvaise configuration. Les sauvegardes fonctionnent entre les versions de Smart Citizen. Les caches du jeu ne sont pas inclus ; ils se reconstruisent automatiquement a partir de vos fichiers de jeu."
+      "at": "Enregistrez tous vos paramètres (préférences, configurations d'étiquettes, votre dossier Star Citizen et vos modifications de texte personnalisées pour chaque canal) dans un seul petit fichier de sauvegarde. Importez-le sur un nouveau PC, après une extraction portable fraîche, ou pour annuler une mauvaise configuration. Les sauvegardes fonctionnent entre les versions de Smart Citizen. Les caches du jeu ne sont pas inclus ; ils se reconstruisent automatiquement à partir de vos fichiers de jeu."
     },
     "export_settings_btn": {
       "ht": "",
-      "at": "Exporter les parametres..."
+      "at": "Exporter les paramètres..."
     },
     "export_settings_tooltip": {
       "ht": "",
-      "at": "Enregistrez vos preferences, votre dossier Star Citizen et vos modifications de texte personnalisees dans un petit fichier zip de sauvegarde (quelques Ko). Conservez-le n'importe ou (drive cloud, cle USB) et importez-le plus tard, sur n'importe quelle version de Smart Citizen, pour restaurer vos parametres."
+      "at": "Enregistrez vos préférences, votre dossier Star Citizen et vos modifications de texte personnalisées dans un petit fichier zip de sauvegarde (quelques Ko). Conservez-le n'importe où (drive cloud, clé USB) et importez-le plus tard, sur n'importe quelle version de Smart Citizen, pour restaurer vos paramètres."
     },
     "import_settings_btn": {
       "ht": "",
-      "at": "Importer les parametres..."
+      "at": "Importer les paramètres..."
     },
     "import_settings_tooltip": {
       "ht": "",
-      "at": "Restaurez un fichier de sauvegarde des parametres cree par n'importe quelle version de Smart Citizen. Vos fichiers user.ini actuels sont d'abord photographies, votre dossier Star Citizen est restaure (ou detecte automatiquement si le chemin de la sauvegarde n'est pas sur ce PC), et Smart Citizen redemarre avec les parametres importes."
+      "at": "Restaurez un fichier de sauvegarde des paramètres créé par n'importe quelle version de Smart Citizen. Vos fichiers user.ini actuels sont d'abord sauvegardés, votre dossier Star Citizen est restauré (ou détecté automatiquement si le chemin de la sauvegarde n'est pas sur ce PC), et Smart Citizen redémarre avec les paramètres importés."
     }
   },
   "enhancements": {
@@ -2676,67 +2676,67 @@
   "settings_backup": {
     "export_dialog_title": {
       "ht": "",
-      "at": "Exporter la sauvegarde des parametres"
+      "at": "Exporter la sauvegarde des paramètres"
     },
     "export_done_title": {
       "ht": "",
-      "at": "Parametres exportes"
+      "at": "Paramètres exportés"
     },
     "export_done_body": {
       "ht": "",
-      "at": "Vos parametres ont ete enregistres dans :\n{path}\n\nInclus : {n_settings} parametres et modifications de texte personnalisees pour : {channels}.\n\nConservez ce fichier n'importe ou, il est petit. Utilisez Importer les parametres pour le restaurer sur un nouveau PC ou apres etre passe a une nouvelle version portable."
+      "at": "Vos paramètres ont été enregistrés dans :\n{path}\n\nInclus : {n_settings} paramètres et modifications de texte personnalisées pour : {channels}.\n\nConservez ce fichier n'importe où, il est petit. Utilisez Importer les paramètres pour le restaurer sur un nouveau PC ou après être passé à une nouvelle version portable."
     },
     "export_failed_title": {
       "ht": "",
-      "at": "Echec de l'exportation"
+      "at": "Échec de l'exportation"
     },
     "export_failed_body": {
       "ht": "",
-      "at": "Impossible d'ecrire le fichier zip de sauvegarde.\n\n{error_type} : {error}"
+      "at": "Impossible d'écrire le fichier zip de sauvegarde.\n\n{error_type} : {error}"
     },
     "import_dialog_title": {
       "ht": "",
-      "at": "Importer la sauvegarde des parametres"
+      "at": "Importer la sauvegarde des paramètres"
     },
     "import_confirm_title": {
       "ht": "",
-      "at": "Importer ces parametres ?"
+      "at": "Importer ces paramètres ?"
     },
     "import_confirm_body": {
       "ht": "",
-      "at": "Sauvegarde creee avec Smart Citizen v{version} le {when}.\n\nElle contient {n_settings} parametres et modifications de texte pour : {channels}.\n\nL'importation superpose ces donnees a vos parametres actuels et remplace user.ini pour les canaux listes (vos fichiers user.ini actuels sont d'abord photographies, donc c'est reversible via Reinitialiser user.ini). Continuer ?"
+      "at": "Sauvegarde créée avec Smart Citizen v{version} le {when}.\n\nElle contient {n_settings} paramètres et modifications de texte pour : {channels}.\n\nL'importation superpose ces données à vos paramètres actuels et remplace user.ini pour les canaux listés (vos fichiers user.ini actuels sont d'abord sauvegardés, donc c'est réversible via Restaurer user.ini). Continuer ?"
     },
     "import_done_title": {
       "ht": "",
-      "at": "Parametres importes"
+      "at": "Paramètres importés"
     },
     "import_done_body_detected": {
       "ht": "",
-      "at": "{applied} parametres et modifications de texte importes pour : {channels}.\n\nLe dossier Star Citizen de la sauvegarde n'est pas sur ce PC, il a donc ete detecte automatiquement a la place :\n{root}\n\nSmart Citizen doit redemarrer pour charger vos parametres importes. Apres le redemarrage, il proposera de regenerer et d'appliquer vos ameliorations."
+      "at": "{applied} paramètres et modifications de texte importés pour : {channels}.\n\nLe dossier Star Citizen de la sauvegarde n'est pas sur ce PC, il a donc été détecté automatiquement à la place :\n{root}\n\nSmart Citizen doit redémarrer pour charger vos paramètres importés. Après le redémarrage, il proposera de régénérer et d'appliquer vos améliorations."
     },
     "import_done_body_no_install": {
       "ht": "",
-      "at": "{applied} parametres et modifications de texte importes pour : {channels}.\n\nAucune installation de Star Citizen n'a ete trouvee sur ce PC ; definissez-la dans l'onglet Configuration apres le redemarrage.\n\nSmart Citizen doit redemarrer pour charger vos parametres importes."
+      "at": "{applied} paramètres et modifications de texte importés pour : {channels}.\n\nAucune installation de Star Citizen n'a été trouvée sur ce PC ; définissez-la dans l'onglet Configuration après le redémarrage.\n\nSmart Citizen doit redémarrer pour charger vos paramètres importés."
     },
     "import_done_body_restored": {
       "ht": "",
-      "at": "{applied} parametres et modifications de texte importes pour : {channels}.\n\nVotre dossier Star Citizen a ete restaure depuis la sauvegarde :\n{root}\n\nSmart Citizen doit redemarrer pour charger vos parametres importes. Apres le redemarrage, il proposera de regenerer et d'appliquer vos ameliorations."
+      "at": "{applied} paramètres et modifications de texte importés pour : {channels}.\n\nVotre dossier Star Citizen a été restauré depuis la sauvegarde :\n{root}\n\nSmart Citizen doit redémarrer pour charger vos paramètres importés. Après le redémarrage, il proposera de régénérer et d'appliquer vos améliorations."
     },
     "import_failed_title": {
       "ht": "",
-      "at": "Echec de l'importation"
+      "at": "Échec de l'importation"
     },
     "import_failed_body": {
       "ht": "",
-      "at": "Impossible d'ecrire les modifications importees.\n\n{error_type} : {error}\n\nAucun parametre n'a ete modifie."
+      "at": "Impossible d'écrire les modifications importées.\n\n{error_type} : {error}\n\nAucun paramètre n'a été modifié."
     },
     "import_invalid_title": {
       "ht": "",
-      "at": "Ce n'est pas une sauvegarde de parametres"
+      "at": "Ce n'est pas une sauvegarde de paramètres"
     },
     "import_invalid_body": {
       "ht": "",
-      "at": "Ce fichier n'a pas pu etre importe :\n\n{error}"
+      "at": "Ce fichier n'a pas pu être importé :\n\n{error}"
     },
     "no_channels": {
       "ht": "",
@@ -2744,11 +2744,11 @@
     },
     "post_import_apply_title": {
       "ht": "",
-      "at": "Presque termine — appliquer a votre jeu ?"
+      "at": "Presque terminé : appliquer à votre jeu ?"
     },
     "post_import_apply_body": {
       "ht": "",
-      "at": "Vos parametres sont importes. La derniere etape consiste a construire vos ameliorations a partir des fichiers de jeu de ce PC et a les ecrire dans le jeu.\n\nLes sauvegardes stockent vos parametres, pas le texte de jeu genere, donc cela doit etre fait une fois sur chaque nouveau PC. Cela prend generalement quelques minutes, un peu plus longtemps la premiere fois, le temps que vos fichiers de jeu soient decompresses.\n\nVous pouvez aussi le faire plus tard avec le bouton Appliquer les ameliorations."
+      "at": "Vos paramètres sont importés. La dernière étape consiste à construire vos améliorations à partir des fichiers de jeu de ce PC et à les écrire dans le jeu.\n\nLes sauvegardes stockent vos paramètres, pas le texte de jeu généré, donc cela doit être fait une fois sur chaque nouveau PC. Cela prend généralement quelques minutes, un peu plus longtemps la première fois, le temps que vos fichiers de jeu soient décompressés.\n\nVous pouvez aussi le faire plus tard avec le bouton Appliquer les améliorations."
     },
     "post_import_apply_now_btn": {
       "ht": "",
@@ -2760,31 +2760,31 @@
     },
     "post_import_no_install_title": {
       "ht": "",
-      "at": "Definissez votre dossier Star Citizen"
+      "at": "Définissez votre dossier Star Citizen"
     },
     "post_import_no_install_body": {
       "ht": "",
-      "at": "Vos parametres importes sont charges, mais aucune installation de Star Citizen n'est encore configuree. Definissez le dossier d'installation dans l'onglet Configuration, puis utilisez Appliquer les ameliorations pour mettre vos personnalisations dans le jeu."
+      "at": "Vos paramètres importés sont chargés, mais aucune installation de Star Citizen n'est encore configurée. Définissez le dossier d'installation dans l'onglet Configuration, puis utilisez Appliquer les améliorations pour mettre vos personnalisations dans le jeu."
     },
     "relaunch_failed_title": {
       "ht": "",
-      "at": "Echec du redemarrage"
+      "at": "Échec du redémarrage"
     },
     "relaunch_failed_body": {
       "ht": "",
-      "at": "Smart Citizen n'a pas pu se relancer. Veuillez le redemarrer manuellement ; vos parametres importes se chargeront alors."
+      "at": "Smart Citizen n'a pas pu se relancer. Veuillez le redémarrer manuellement ; vos paramètres importés se chargeront alors."
     },
     "restart_now_btn": {
       "ht": "",
-      "at": "Redemarrer maintenant"
+      "at": "Redémarrer maintenant"
     },
     "restart_later_btn": {
       "ht": "",
-      "at": "Redemarrer plus tard"
+      "at": "Redémarrer plus tard"
     },
     "zip_filter": {
       "ht": "",
-      "at": "Sauvegarde des parametres (*.zip)"
+      "at": "Sauvegarde des paramètres (*.zip)"
     }
   }
 }

--- a/languages/portuguese_br/ui.json
+++ b/languages/portuguese_br/ui.json
@@ -812,27 +812,27 @@
     },
     "backup_group": {
       "ht": "",
-      "at": "Backup de Configuracoes"
+      "at": "Backup de Configurações"
     },
     "backup_desc": {
       "ht": "",
-      "at": "Salve todas as suas configuracoes (preferencias, configuracoes de tags, sua pasta do Star Citizen e suas substituicoes de texto personalizadas para cada canal) em um unico arquivo de backup pequeno. Importe em um PC novo, apos descompactar uma versao portatil nova, ou para desfazer uma configuracao errada. Os backups funcionam entre versoes do Smart Citizen. Os caches do jogo nao sao incluidos; eles se reconstroem automaticamente a partir dos arquivos do seu jogo."
+      "at": "Salve todas as suas configurações (preferências, configurações de tags, sua pasta do Star Citizen e suas substituições de texto personalizadas para cada canal) em um único arquivo de backup pequeno. Importe em um PC novo, após descompactar uma versão portátil nova, ou para desfazer uma configuração errada. Os backups funcionam entre versões do Smart Citizen. Os caches do jogo não são incluídos; eles se reconstroem automaticamente a partir dos arquivos do seu jogo."
     },
     "export_settings_btn": {
       "ht": "",
-      "at": "Exportar Configuracoes..."
+      "at": "Exportar Configurações..."
     },
     "export_settings_tooltip": {
       "ht": "",
-      "at": "Salve suas preferencias, pasta do Star Citizen e substituicoes de texto personalizadas em um pequeno zip de backup (poucos KB). Guarde onde quiser (nuvem, pendrive) e importe depois, em qualquer versao do Smart Citizen, para restaurar suas configuracoes."
+      "at": "Salve suas preferências, pasta do Star Citizen e substituições de texto personalizadas em um pequeno zip de backup (poucos KB). Guarde onde quiser (nuvem, pendrive) e importe depois, em qualquer versão do Smart Citizen, para restaurar suas configurações."
     },
     "import_settings_btn": {
       "ht": "",
-      "at": "Importar Configuracoes..."
+      "at": "Importar Configurações..."
     },
     "import_settings_tooltip": {
       "ht": "",
-      "at": "Restaura um zip de backup de configuracoes feito por qualquer versao do Smart Citizen. Seus arquivos user.ini atuais sao capturados primeiro, sua pasta do Star Citizen e restaurada (ou detectada automaticamente se o caminho do backup nao estiver neste PC), e o Smart Citizen reinicia com as configuracoes importadas."
+      "at": "Restaura um zip de backup de configurações feito por qualquer versão do Smart Citizen. Seus arquivos user.ini atuais são salvos primeiro, sua pasta do Star Citizen é restaurada (ou detectada automaticamente se o caminho do backup não estiver neste PC), e o Smart Citizen reinicia com as configurações importadas."
     }
   },
   "enhancements": {
@@ -2676,15 +2676,15 @@
   "settings_backup": {
     "export_dialog_title": {
       "ht": "",
-      "at": "Exportar Backup de Configuracoes"
+      "at": "Exportar Backup de Configurações"
     },
     "export_done_title": {
       "ht": "",
-      "at": "Configuracoes Exportadas"
+      "at": "Configurações Exportadas"
     },
     "export_done_body": {
       "ht": "",
-      "at": "Suas configuracoes foram salvas em:\n{path}\n\nIncluido: {n_settings} configuracoes e substituicoes de texto personalizadas para: {channels}.\n\nGuarde este arquivo onde quiser, ele e pequeno. Use Importar Configuracoes para restaura-lo em um PC novo ou apos migrar para uma nova versao portatil."
+      "at": "Suas configurações foram salvas em:\n{path}\n\nIncluído: {n_settings} configurações e substituições de texto personalizadas para: {channels}.\n\nGuarde este arquivo onde quiser, ele é pequeno. Use Importar Configurações para restaurá-lo em um PC novo ou após migrar para uma nova versão portátil."
     },
     "export_failed_title": {
       "ht": "",
@@ -2692,35 +2692,35 @@
     },
     "export_failed_body": {
       "ht": "",
-      "at": "Nao foi possivel gravar o zip de backup.\n\n{error_type}: {error}"
+      "at": "Não foi possível gravar o zip de backup.\n\n{error_type}: {error}"
     },
     "import_dialog_title": {
       "ht": "",
-      "at": "Importar Backup de Configuracoes"
+      "at": "Importar Backup de Configurações"
     },
     "import_confirm_title": {
       "ht": "",
-      "at": "Importar estas configuracoes?"
+      "at": "Importar estas configurações?"
     },
     "import_confirm_body": {
       "ht": "",
-      "at": "Backup feito com Smart Citizen v{version} em {when}.\n\nContem {n_settings} configuracoes e substituicoes de texto para: {channels}.\n\nImportar sobrepoe isso as suas configuracoes atuais e substitui o user.ini dos canais listados (seus arquivos user.ini atuais sao capturados primeiro, entao isso e reversivel via Redefinir user.ini). Continuar?"
+      "at": "Backup feito com Smart Citizen v{version} em {when}.\n\nContém {n_settings} configurações e substituições de texto para: {channels}.\n\nImportar sobrepõe isso às suas configurações atuais e substitui o user.ini dos canais listados (seus arquivos user.ini atuais são salvos primeiro, então isso é reversível via Restaurar user.ini). Continuar?"
     },
     "import_done_title": {
       "ht": "",
-      "at": "Configuracoes Importadas"
+      "at": "Configurações Importadas"
     },
     "import_done_body_detected": {
       "ht": "",
-      "at": "{applied} configuracoes e substituicoes de texto importadas para: {channels}.\n\nA pasta do Star Citizen do backup nao esta neste PC, entao foi detectada automaticamente:\n{root}\n\nO Smart Citizen precisa reiniciar para carregar suas configuracoes importadas. Apos reiniciar, ele oferecera para regenerar e aplicar seus aprimoramentos."
+      "at": "{applied} configurações e substituições de texto importadas para: {channels}.\n\nA pasta do Star Citizen do backup não está neste PC, então foi detectada automaticamente:\n{root}\n\nO Smart Citizen precisa reiniciar para carregar suas configurações importadas. Após reiniciar, ele oferecerá regenerar e aplicar seus aprimoramentos."
     },
     "import_done_body_no_install": {
       "ht": "",
-      "at": "{applied} configuracoes e substituicoes de texto importadas para: {channels}.\n\nNenhuma instalacao do Star Citizen foi encontrada neste PC; defina-a na aba Configuracao apos reiniciar.\n\nO Smart Citizen precisa reiniciar para carregar suas configuracoes importadas."
+      "at": "{applied} configurações e substituições de texto importadas para: {channels}.\n\nNenhuma instalação do Star Citizen foi encontrada neste PC; defina-a na aba Configuração após reiniciar.\n\nO Smart Citizen precisa reiniciar para carregar suas configurações importadas."
     },
     "import_done_body_restored": {
       "ht": "",
-      "at": "{applied} configuracoes e substituicoes de texto importadas para: {channels}.\n\nSua pasta do Star Citizen foi restaurada a partir do backup:\n{root}\n\nO Smart Citizen precisa reiniciar para carregar suas configuracoes importadas. Apos reiniciar, ele oferecera para regenerar e aplicar seus aprimoramentos."
+      "at": "{applied} configurações e substituições de texto importadas para: {channels}.\n\nSua pasta do Star Citizen foi restaurada a partir do backup:\n{root}\n\nO Smart Citizen precisa reiniciar para carregar suas configurações importadas. Após reiniciar, ele oferecerá regenerar e aplicar seus aprimoramentos."
     },
     "import_failed_title": {
       "ht": "",
@@ -2728,15 +2728,15 @@
     },
     "import_failed_body": {
       "ht": "",
-      "at": "Nao foi possivel gravar as substituicoes importadas.\n\n{error_type}: {error}\n\nNenhuma configuracao foi alterada."
+      "at": "Não foi possível gravar as substituições importadas.\n\n{error_type}: {error}\n\nNenhuma configuração foi alterada."
     },
     "import_invalid_title": {
       "ht": "",
-      "at": "Isto Nao e um Backup de Configuracoes"
+      "at": "Isto Não é um Backup de Configurações"
     },
     "import_invalid_body": {
       "ht": "",
-      "at": "Este arquivo nao pode ser importado:\n\n{error}"
+      "at": "Este arquivo não pôde ser importado:\n\n{error}"
     },
     "no_channels": {
       "ht": "",
@@ -2744,11 +2744,11 @@
     },
     "post_import_apply_title": {
       "ht": "",
-      "at": "Quase Pronto — Aplicar ao Seu Jogo?"
+      "at": "Quase Pronto: Aplicar ao Seu Jogo?"
     },
     "post_import_apply_body": {
       "ht": "",
-      "at": "Suas configuracoes foram importadas. A ultima etapa e gerar seus aprimoramentos a partir dos arquivos de jogo deste PC e grava-los no jogo.\n\nOs backups guardam suas configuracoes, nao o texto de jogo gerado, entao isso precisa ser feito uma vez em cada PC novo. Geralmente leva alguns minutos, um pouco mais na primeira vez, enquanto os arquivos do jogo sao descompactados.\n\nVoce tambem pode fazer isso depois com o botao Aplicar Aprimoramentos."
+      "at": "Suas configurações foram importadas. A última etapa é gerar seus aprimoramentos a partir dos arquivos de jogo deste PC e gravá-los no jogo.\n\nOs backups guardam suas configurações, não o texto de jogo gerado, então isso precisa ser feito uma vez em cada PC novo. Geralmente leva alguns minutos, um pouco mais na primeira vez, enquanto os arquivos do jogo são descompactados.\n\nVocê também pode fazer isso depois com o botão Aplicar Aprimoramentos."
     },
     "post_import_apply_now_btn": {
       "ht": "",
@@ -2764,7 +2764,7 @@
     },
     "post_import_no_install_body": {
       "ht": "",
-      "at": "Suas configuracoes importadas foram carregadas, mas nenhuma instalacao do Star Citizen esta configurada ainda. Defina a pasta de instalacao na aba Configuracao e use Aplicar Aprimoramentos para colocar suas personalizacoes no jogo."
+      "at": "Suas configurações importadas foram carregadas, mas nenhuma instalação do Star Citizen está configurada ainda. Defina a pasta de instalação na aba Configuração e use Aplicar Aprimoramentos para colocar suas personalizações no jogo."
     },
     "relaunch_failed_title": {
       "ht": "",
@@ -2772,7 +2772,7 @@
     },
     "relaunch_failed_body": {
       "ht": "",
-      "at": "O Smart Citizen nao conseguiu reiniciar sozinho. Inicie-o novamente manualmente; suas configuracoes importadas serao carregadas entao."
+      "at": "O Smart Citizen não conseguiu reiniciar sozinho. Inicie-o novamente manualmente; suas configurações importadas serão carregadas então."
     },
     "restart_now_btn": {
       "ht": "",
@@ -2784,7 +2784,7 @@
     },
     "zip_filter": {
       "ht": "",
-      "at": "Backup de configuracoes (*.zip)"
+      "at": "Backup de configurações (*.zip)"
     }
   }
 }

--- a/languages/spanish/ui.json
+++ b/languages/spanish/ui.json
@@ -816,7 +816,7 @@
     },
     "backup_desc": {
       "ht": "",
-      "at": "Guarda todos tus ajustes (preferencias, configuraciones de etiquetas, tu carpeta de Star Citizen y tus modificaciones de texto personalizadas para cada canal) en un pequeno archivo de copia de seguridad. Importalo en un PC nuevo, tras descomprimir una version portable nueva, o para deshacer una mala configuracion. Las copias de seguridad funcionan entre versiones de Smart Citizen. Las cachés del juego no se incluyen; se reconstruyen automaticamente desde tus archivos de juego."
+      "at": "Guarda todos tus ajustes (preferencias, configuraciones de etiquetas, tu carpeta de Star Citizen y tus modificaciones de texto personalizadas para cada canal) en un pequeño archivo de copia de seguridad. Impórtalo en un PC nuevo, tras descomprimir una versión portable nueva, o para deshacer una mala configuración. Las copias de seguridad funcionan entre versiones de Smart Citizen. Las cachés del juego no se incluyen; se reconstruyen automáticamente desde tus archivos de juego."
     },
     "export_settings_btn": {
       "ht": "",
@@ -824,7 +824,7 @@
     },
     "export_settings_tooltip": {
       "ht": "",
-      "at": "Guarda tus preferencias, carpeta de Star Citizen y modificaciones de texto personalizadas en un pequeno zip de copia de seguridad (unos pocos KB). Guardalo donde quieras (nube, USB) e importalo mas tarde, en cualquier version de Smart Citizen, para restaurar tus ajustes."
+      "at": "Guarda tus preferencias, carpeta de Star Citizen y modificaciones de texto personalizadas en un pequeño zip de copia de seguridad (unos pocos KB). Guárdalo donde quieras (nube, USB) e impórtalo más tarde, en cualquier versión de Smart Citizen, para restaurar tus ajustes."
     },
     "import_settings_btn": {
       "ht": "",
@@ -832,7 +832,7 @@
     },
     "import_settings_tooltip": {
       "ht": "",
-      "at": "Restaura un zip de copia de seguridad de ajustes creado por cualquier version de Smart Citizen. Tus archivos user.ini actuales se respaldan primero, tu carpeta de Star Citizen se restaura (o se detecta automaticamente si la ruta de la copia no esta en este PC), y Smart Citizen se reinicia con los ajustes importados."
+      "at": "Restaura un zip de copia de seguridad de ajustes creado por cualquier versión de Smart Citizen. Tus archivos user.ini actuales se respaldan primero, tu carpeta de Star Citizen se restaura (o se detecta automáticamente si la ruta de la copia no está en este PC), y Smart Citizen se reinicia con los ajustes importados."
     }
   },
   "enhancements": {
@@ -2684,7 +2684,7 @@
     },
     "export_done_body": {
       "ht": "",
-      "at": "Tus ajustes se guardaron en:\n{path}\n\nIncluye: {n_settings} ajustes y modificaciones de texto personalizadas para: {channels}.\n\nGuarda este archivo donde quieras, es pequeno. Usa Importar ajustes para restaurarlo en un PC nuevo o tras pasar a una nueva version portable."
+      "at": "Tus ajustes se guardaron en:\n{path}\n\nIncluye: {n_settings} ajustes y modificaciones de texto personalizadas para: {channels}.\n\nGuarda este archivo donde quieras, es pequeño. Usa Importar ajustes para restaurarlo en un PC nuevo o tras pasar a una nueva versión portable."
     },
     "export_failed_title": {
       "ht": "",
@@ -2704,7 +2704,7 @@
     },
     "import_confirm_body": {
       "ht": "",
-      "at": "Copia de seguridad creada con Smart Citizen v{version} el {when}.\n\nContiene {n_settings} ajustes y modificaciones de texto para: {channels}.\n\nImportar superpone esto sobre tus ajustes actuales y reemplaza user.ini para los canales listados (tus archivos user.ini actuales se respaldan primero, asi que es reversible mediante Restablecer user.ini). ¿Continuar?"
+      "at": "Copia de seguridad creada con Smart Citizen v{version} el {when}.\n\nContiene {n_settings} ajustes y modificaciones de texto para: {channels}.\n\nImportar superpone esto sobre tus ajustes actuales y reemplaza user.ini para los canales listados (tus archivos user.ini actuales se respaldan primero, así que es reversible mediante Restaurar user.ini). ¿Continuar?"
     },
     "import_done_title": {
       "ht": "",
@@ -2712,15 +2712,15 @@
     },
     "import_done_body_detected": {
       "ht": "",
-      "at": "Se importaron {applied} ajustes y modificaciones de texto para: {channels}.\n\nLa carpeta de Star Citizen de la copia no esta en este PC, asi que se detecto automaticamente en su lugar:\n{root}\n\nSmart Citizen necesita reiniciarse para cargar tus ajustes importados. Tras el reinicio, ofrecera regenerar y aplicar tus mejoras."
+      "at": "Se importaron {applied} ajustes y modificaciones de texto para: {channels}.\n\nLa carpeta de Star Citizen de la copia no está en este PC, así que se detectó automáticamente en su lugar:\n{root}\n\nSmart Citizen necesita reiniciarse para cargar tus ajustes importados. Tras el reinicio, ofrecerá regenerar y aplicar tus mejoras."
     },
     "import_done_body_no_install": {
       "ht": "",
-      "at": "Se importaron {applied} ajustes y modificaciones de texto para: {channels}.\n\nNo se encontro ninguna instalacion de Star Citizen en este PC; configurala en la pestaña Configuracion tras el reinicio.\n\nSmart Citizen necesita reiniciarse para cargar tus ajustes importados."
+      "at": "Se importaron {applied} ajustes y modificaciones de texto para: {channels}.\n\nNo se encontró ninguna instalación de Star Citizen en este PC; configúrala en la pestaña Configuración tras el reinicio.\n\nSmart Citizen necesita reiniciarse para cargar tus ajustes importados."
     },
     "import_done_body_restored": {
       "ht": "",
-      "at": "Se importaron {applied} ajustes y modificaciones de texto para: {channels}.\n\nTu carpeta de Star Citizen se restauro desde la copia de seguridad:\n{root}\n\nSmart Citizen necesita reiniciarse para cargar tus ajustes importados. Tras el reinicio, ofrecera regenerar y aplicar tus mejoras."
+      "at": "Se importaron {applied} ajustes y modificaciones de texto para: {channels}.\n\nTu carpeta de Star Citizen se restauró desde la copia de seguridad:\n{root}\n\nSmart Citizen necesita reiniciarse para cargar tus ajustes importados. Tras el reinicio, ofrecerá regenerar y aplicar tus mejoras."
     },
     "import_failed_title": {
       "ht": "",
@@ -2728,7 +2728,7 @@
     },
     "import_failed_body": {
       "ht": "",
-      "at": "No se pudieron escribir las modificaciones importadas.\n\n{error_type}: {error}\n\nNo se cambio ningun ajuste."
+      "at": "No se pudieron escribir las modificaciones importadas.\n\n{error_type}: {error}\n\nNo se cambió ningún ajuste."
     },
     "import_invalid_title": {
       "ht": "",
@@ -2748,7 +2748,7 @@
     },
     "post_import_apply_body": {
       "ht": "",
-      "at": "Tus ajustes estan importados. El ultimo paso es generar tus mejoras a partir de los archivos de juego de este PC y escribirlas en el juego.\n\nLas copias de seguridad guardan tus ajustes, no el texto de juego generado, asi que esto debe hacerse una vez en cada PC nuevo. Normalmente tarda unos minutos, un poco mas la primera vez, mientras se descomprimen tus archivos de juego.\n\nTambien puedes hacer esto mas tarde con el boton Aplicar mejoras."
+      "at": "Tus ajustes están importados. El último paso es generar tus mejoras a partir de los archivos de juego de este PC y escribirlas en el juego.\n\nLas copias de seguridad guardan tus ajustes, no el texto de juego generado, así que esto debe hacerse una vez en cada PC nuevo. Normalmente tarda unos minutos, un poco más la primera vez, mientras se descomprimen tus archivos de juego.\n\nTambién puedes hacer esto más tarde con el botón Aplicar mejoras."
     },
     "post_import_apply_now_btn": {
       "ht": "",
@@ -2756,7 +2756,7 @@
     },
     "post_import_apply_later_btn": {
       "ht": "",
-      "at": "Mas tarde"
+      "at": "Más tarde"
     },
     "post_import_no_install_title": {
       "ht": "",
@@ -2764,7 +2764,7 @@
     },
     "post_import_no_install_body": {
       "ht": "",
-      "at": "Tus ajustes importados estan cargados, pero aun no hay ninguna instalacion de Star Citizen configurada. Configura la carpeta de instalacion en la pestaña Configuracion, y luego usa Aplicar mejoras para poner tus personalizaciones en el juego."
+      "at": "Tus ajustes importados están cargados, pero aún no hay ninguna instalación de Star Citizen configurada. Configura la carpeta de instalación en la pestaña Configuración, y luego usa Aplicar mejoras para poner tus personalizaciones en el juego."
     },
     "relaunch_failed_title": {
       "ht": "",
@@ -2772,7 +2772,7 @@
     },
     "relaunch_failed_body": {
       "ht": "",
-      "at": "Smart Citizen no pudo reiniciarse. Por favor, inicialo de nuevo manualmente; tus ajustes importados se cargaran entonces."
+      "at": "Smart Citizen no pudo reiniciarse. Por favor, inícialo de nuevo manualmente; tus ajustes importados se cargarán entonces."
     },
     "restart_now_btn": {
       "ht": "",
@@ -2780,7 +2780,7 @@
     },
     "restart_later_btn": {
       "ht": "",
-      "at": "Reiniciar mas tarde"
+      "at": "Reiniciar más tarde"
     },
     "zip_filter": {
       "ht": "",


### PR DESCRIPTION
## Summary
Follow-up to #311's review findings. Two fixes to the French, Spanish, and Portuguese strings the Settings Backup feature added:

- **The import-confirm dialog named the wrong recovery button.** It said the import is reversible via Reset user.ini ("Réinitialiser" / "Restablecer" / "Redefinir"), which is the edit-wiping tool. English references **Restore user.ini**; each language now uses its own `config.restore_user_ini_btn` wording ("Restaurer" / "Restaurar" / "Restaurar").
- **Diacritics restored.** The whole `settings_backup.*` / `config.backup*` key set shipped accent-free ("parametres", "configuracoes"), inconsistent with the rest of those files.

All strings stay `at`-only with `ht: ""` so translators still find them the usual way. Provenance entry added to `languages/TRANSLATIONS.md`.

## Testing
- `tests/test_i18n.py`, `tests/test_language_paths.py`, `tests/test_available_languages.py` pass; all three ui.json files re-validated as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)