### PR TITLE
Fix Blueprint Tracker "stacking" fake items from commodity data (#354)

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -50,7 +50,9 @@ from src.gui.workers import (
     StartupSyncWorker,
 )
 from src.merger.ini_merger import merge_sources_by_hierarchy
-from src.models.string_model import StringEntry, is_favoritable_ship
+from src.models.string_model import (
+    CATEGORY_MISSIONS, StringEntry, is_favoritable_ship,
+)
 from src.parser.ini_parser import load_source_files, load_sources_from_settings, parse_ini_file
 from src.gui.update_dialog import UpdateDialog
 from src.utils.app_updater import AppUpdateCheckWorker, AppUpdateDownloadWorker
@@ -5008,7 +5010,7 @@ class MainWindow(QMainWindow):
         entry_categories = set(e.category for e in self.entries)
 
         # Always include standard categories, even if no entries exist for them yet
-        standard_categories = {"Ships", "Ship Items", "Missions", "Commodities", "Other"}
+        standard_categories = {"Ships", "Ship Items", CATEGORY_MISSIONS, "Commodities", "Other"}
         categories = sorted(standard_categories | entry_categories)
 
         self.category_combo.blockSignals(True)

--- a/src/models/string_model.py
+++ b/src/models/string_model.py
@@ -86,6 +86,23 @@ _MISSION_PREFIXES = (
     "wantedlevel", "wstr_", "xenothreat_",
 )
 
+# The category name for mission entries. Named because #354 turned it from a
+# display string into a load-bearing gate: blueprint_meta and entry_filter both
+# refuse to scan an entry for a POTENTIAL BLUEPRINTS section unless it carries
+# this exact category, so a typo in either would silently empty the Blueprint
+# Tracker rather than fail loudly. Every place that decides "is this a mission
+# entry" reads this constant: the classifier below, ini_parser's source-based
+# override, and the two scan gates.
+#
+# Deliberately not localized. This is an internal classification token, not UI
+# text -- src/parser and src/models contain no tr() calls at all -- so the gates
+# keep working for a user running the app in German.
+#
+# AppSettings.ENHANCEMENT_LABELS["missions"] must stay equal to this: the
+# parser routes enhancement-sourced entries through that label, so the two
+# meeting is what lets a mission enhancement pass the same gate.
+CATEGORY_MISSIONS = "Missions"
+
 
 @lru_cache(maxsize=None)
 def _extract_category_impl(key: str) -> str:
@@ -156,7 +173,7 @@ def _extract_category_impl(key: str) -> str:
     if "journal" in key_lower:
         return "Journal"
     if key_lower.startswith(_MISSION_PREFIXES):
-        return "Missions"
+        return CATEGORY_MISSIONS
 
     return "Other"
 

--- a/src/parser/ini_parser.py
+++ b/src/parser/ini_parser.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from src.models.string_model import StringEntry
+from src.models.string_model import CATEGORY_MISSIONS, StringEntry
 from src.merger.ini_merger import merge_sources_by_hierarchy
 from src.utils.ini_io import read_ini_text
 from src.utils.perf import timed
@@ -213,7 +213,7 @@ def load_source_files(
 
         # Determine category: source-based override first, then key-prefix fallback
         if source == 'contracts':
-            category = 'Missions'
+            category = CATEGORY_MISSIONS
         elif 'journal' in key.lower():
             category = 'Journal'
         elif enhancements_key_categories and key in enhancements_key_categories:

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from src.models.string_model import (
+    CATEGORY_MISSIONS,
     _ARMOR_GEAR_WORDS,
     _FPS_WEAPON_WORDS,
     _SHIP_WEAPON_SIZE_RE,
@@ -508,7 +509,7 @@ def build_blueprint_metadata(entries) -> dict:
         # mission's blueprint reward list -- fabricating fake, unownable
         # "items" that show up identically in both Available and Owned
         # (reported as the tracker "stacking" components).
-        if cat == "Missions" and has_bp_section(val):
+        if cat == CATEGORY_MISSIONS and has_bp_section(val):
             dm = _DESC_KEY_RE.match(key)
             pair = _title_pair_key(dm.group("base"), dm.group("num")) if dm else None
             bp_descs.append((pair, val))

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -496,7 +496,19 @@ def build_blueprint_metadata(entries) -> dict:
             titles[_title_pair_key(tm.group("base"), tm.group("num"))] = \
                 clean_mission_title(val)
 
-        if has_bp_section(val):
+        # #354: gated to Missions entries only. A POTENTIAL BLUEPRINTS
+        # section only ever legitimately exists in a mission's Desc text --
+        # without this gate, has_bp_section runs on every entry's value
+        # unconditionally, so if a user's independently-configurable
+        # "Blueprint Data" mission-commodity header (settings.py's
+        # MISSION_HEADER_BLUEPRINT_DATA) happens to collide with the
+        # "blueprints" header text, a commodity's crafting-material-usage
+        # summary ("- Power Plants: 10 items", "- Quantum Drives: 3 items
+        # (S1-S3)", one per raw material) gets scanned as if it were a real
+        # mission's blueprint reward list -- fabricating fake, unownable
+        # "items" that show up identically in both Available and Owned
+        # (reported as the tracker "stacking" components).
+        if cat == "Missions" and has_bp_section(val):
             dm = _DESC_KEY_RE.match(key)
             pair = _title_pair_key(dm.group("base"), dm.group("num")) if dm else None
             bp_descs.append((pair, val))

--- a/src/utils/entry_filter.py
+++ b/src/utils/entry_filter.py
@@ -130,7 +130,13 @@ def filter_entry_indices(
         if bp_titles_only or bp_descs_only:
             val = entry.custom_value or entry.original_value
             is_bp_title = bp_titles_only and "[BP" in val
-            is_bp_desc = bp_descs_only and has_bp_section(val)
+            # #354: gated to Missions entries -- see blueprint_meta.py's
+            # matching gate for why (a commodity's independently-renameable
+            # "Blueprint Data" header can otherwise collide with this check).
+            is_bp_desc = (
+                bp_descs_only and entry.category == "Missions"
+                and has_bp_section(val)
+            )
             if not (is_bp_title or is_bp_desc):
                 continue
         if active_filter_fns:

--- a/src/utils/entry_filter.py
+++ b/src/utils/entry_filter.py
@@ -7,7 +7,9 @@ tested independently of Qt.
 import logging
 
 from src.gui.string_table_model import NUM_COLUMNS
-from src.models.string_model import StringEntry, is_favoritable_ship
+from src.models.string_model import (
+    CATEGORY_MISSIONS, StringEntry, is_favoritable_ship,
+)
 from src.utils.owned_items import has_bp_section
 from src.utils.ship_sort_prefix import get_order
 
@@ -129,14 +131,24 @@ def filter_entry_indices(
         # carries the enhancement) is what's shown, so test that.
         if bp_titles_only or bp_descs_only:
             val = entry.custom_value or entry.original_value
-            is_bp_title = bp_titles_only and "[BP" in val
-            # #354: gated to Missions entries -- see blueprint_meta.py's
-            # matching gate for why (a commodity's independently-renameable
-            # "Blueprint Data" header can otherwise collide with this check).
-            is_bp_desc = (
-                bp_descs_only and entry.category == "Missions"
-                and has_bp_section(val)
-            )
+            # #354: both halves are gated to Missions entries. The desc gate is
+            # the reported bug -- a commodity's independently-renameable
+            # "Blueprint Data" header can collide with the blueprints header,
+            # so has_bp_section matched a crafting-material summary and
+            # fabricated unownable items (see blueprint_meta.py's matching
+            # gate). The title gate is the same reasoning applied to the same
+            # question: "[BP" only means "blueprint mission" on a mission
+            # title, and leaving one half ungated invites the next reader to
+            # assume the asymmetry was load-bearing when it was an oversight.
+            #
+            # entry.category is read directly, not via getattr, because this
+            # parameter is typed list[StringEntry] and category is a required
+            # field. blueprint_meta guards the same read because its own
+            # contract is duck-typed ("any iterable of objects exposing
+            # key/original_value/category"), so the two differ on purpose.
+            is_mission = entry.category == CATEGORY_MISSIONS
+            is_bp_title = bp_titles_only and is_mission and "[BP" in val
+            is_bp_desc = bp_descs_only and is_mission and has_bp_section(val)
             if not (is_bp_title or is_bp_desc):
                 continue
         if active_filter_fns:

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -312,6 +312,25 @@ def test_no_blueprint_entries_is_empty():
     assert set(meta) == {normalize_item_name(n) for n, _ in MANUAL_BLUEPRINT_ITEMS}
 
 
+def test_non_mission_entry_with_colliding_header_is_not_scanned():
+    """#354: the Blueprint Tracker "stacked" fake items like "Power Plants:
+    10 items" because a commodity's independently-renameable "Blueprint
+    Data" header can collide with the "blueprints" mission header, and
+    has_bp_section() ran on every entry's value unconditionally --
+    scanning a commodity's crafting-material-usage summary as if it were a
+    real mission's blueprint reward list. Only "Missions"-category entries
+    should ever be scanned this way."""
+    commodity_desc = (
+        "Iron Ore is a common metal.\\n<EM3>POTENTIAL BLUEPRINTS</EM3>"
+        "\\n- Power Plants: 10 items\\n- Quantum Drives: 3 items (S1-S3)"
+    )
+    meta = build_blueprint_metadata(
+        [_Entry("items_commodities_iron_desc", commodity_desc, "Commodities")]
+    )
+    assert "Power Plants: 10 items" not in meta
+    assert "Quantum Drives: 3 items (S1-S3)" not in meta
+
+
 class TestManualBlueprintItems:
     """#267: XenoThreat "Purgatory Camo" items were never advertised via any
     mission's POTENTIAL BLUEPRINTS text (CIG announced them on their own

--- a/tests/test_entry_filter.py
+++ b/tests/test_entry_filter.py
@@ -177,11 +177,12 @@ def test_favorites_marker_searchable_in_star_column():
 
 def _bp_entries():
     return [
-        _e("title_bp", original_value="Retrieve Cargo Haul <EM4>[BP]</EM4>"),
-        _e("title_bpq", original_value="Recoup Stolen Haul <EM4>[BP?]</EM4>"),
-        _e("desc_bp", original_value="POSTING...\n<EM4>POTENTIAL BLUEPRINTS</EM4>\n- Antium Core"),
-        _e("plain_title", original_value="Some Mission"),
-        _e("plain_desc", original_value="A description with no rewards section"),
+        _e("title_bp", category="Missions", original_value="Retrieve Cargo Haul <EM4>[BP]</EM4>"),
+        _e("title_bpq", category="Missions", original_value="Recoup Stolen Haul <EM4>[BP?]</EM4>"),
+        _e("desc_bp", category="Missions",
+           original_value="POSTING...\n<EM4>POTENTIAL BLUEPRINTS</EM4>\n- Antium Core"),
+        _e("plain_title", category="Missions", original_value="Some Mission"),
+        _e("plain_desc", category="Missions", original_value="A description with no rewards section"),
     ]
 
 
@@ -199,6 +200,18 @@ def test_bp_descs_only_keeps_potential_blueprints_bodies():
     assert result == [2]  # the POTENTIAL BLUEPRINTS body only
 
 
+def test_bp_descs_only_excludes_non_mission_colliding_header():
+    """#354: a commodity whose value happens to contain matching header
+    text (e.g. a renamed "Blueprint Data" header colliding with the
+    "blueprints" header) must not be picked up here either -- only
+    "Missions"-category entries qualify."""
+    e = [_e("items_commodities_iron_desc", category="Commodities",
+            original_value="Iron Ore.\n<EM3>POTENTIAL BLUEPRINTS</EM3>\n- Power Plants: 10 items")]
+    result = filter_entry_indices(e, {}, _no_filters(), "All", "All", False, False, "★",
+                                  bp_descs_only=True)
+    assert result == []
+
+
 def test_both_bp_flags_show_titles_or_descs():
     e = _bp_entries()
     result = filter_entry_indices(e, {}, _no_filters(), "All", "All", False, False, "★",
@@ -213,11 +226,11 @@ def test_bp_descs_only_recognises_multiple_blueprint_pools_header():
     follow-up) -- pre-fix, the "BP Descriptions" checkbox only recognised
     "POTENTIAL BLUEPRINTS" and silently excluded these mission bodies."""
     entries = [
-        _e("desc_pools", original_value=(
+        _e("desc_pools", category="Missions", original_value=(
             "POSTING...\n<EM4>MULTIPLE BLUEPRINT POOLS</EM4>"
             "\n<EM4>Pool 1</EM4>\n- Helix I Mining Laser (Mining Laser)"
         )),
-        _e("plain_desc", original_value="A description with no rewards section"),
+        _e("plain_desc", category="Missions", original_value="A description with no rewards section"),
     ]
     result = filter_entry_indices(entries, {}, _no_filters(), "All", "All", False, False, "★",
                                   bp_descs_only=True)

--- a/tests/test_entry_filter.py
+++ b/tests/test_entry_filter.py
@@ -200,6 +200,33 @@ def test_bp_descs_only_keeps_potential_blueprints_bodies():
     assert result == [2]  # the POTENTIAL BLUEPRINTS body only
 
 
+def test_enhancement_label_matches_the_category_constant():
+    """#354's gate compares against CATEGORY_MISSIONS, but the parser can
+    assign a category from AppSettings.ENHANCEMENT_LABELS instead (a mission
+    entry sourced from mission_rewards_enhancements.ini takes that route, not
+    the key-prefix classifier). The two have to spell it identically or those
+    entries silently fail the gate and vanish from the Blueprint Tracker.
+
+    Documented on the constant; asserted here so it cannot drift quietly.
+    """
+    from src.models.string_model import CATEGORY_MISSIONS
+    from src.utils.settings import AppSettings
+
+    assert AppSettings.ENHANCEMENT_LABELS["missions"] == CATEGORY_MISSIONS
+
+
+def test_bp_titles_only_excludes_non_mission_entry():
+    """#354 symmetry: "[BP" only means "blueprint mission" on a mission title.
+    The desc half was gated when the bug was reported; leaving the title half
+    open would have let the same class of false positive through, and read as
+    a deliberate asymmetry to whoever touched this next."""
+    e = [_e("items_commodities_iron_desc", category="Commodities",
+            original_value="Iron Ore. Not a mission. <EM4>[BP]</EM4>")]
+    result = filter_entry_indices(e, {}, _no_filters(), "All", "All", False, False, "★",
+                                  bp_titles_only=True)
+    assert result == []
+
+
 def test_bp_descs_only_excludes_non_mission_colliding_header():
     """#354: a commodity whose value happens to contain matching header
     text (e.g. a renamed "Blueprint Data" header colliding with the
@@ -239,8 +266,11 @@ def test_bp_descs_only_recognises_multiple_blueprint_pools_header():
 
 def test_bp_filter_reads_custom_override_when_present():
     # A user override on a title row is what's shown, so the tag must be read
-    # from custom_value when set.
-    e = [_e("t", original_value="bare title", custom_value="Custom <EM4>[BP]</EM4>")]
+    # from custom_value when set. category="Missions" because #354 gates both
+    # bp_* checks on it; this test is about custom_value precedence, so it
+    # supplies the category rather than relying on the default.
+    e = [_e("t", category="Missions",
+            original_value="bare title", custom_value="Custom <EM4>[BP]</EM4>")]
     result = filter_entry_indices(e, {}, _no_filters(), "All", "All", False, False, "★",
                                   bp_titles_only=True)
     assert result == [0]


### PR DESCRIPTION
Fixes #354.

## Summary
- Reported via Discord: the Blueprint Tracker's Available and Owned lists were "stacking" fake entries like `"Power Plants: 10 items"` and `"Quantum Drives: 3 items (S1-S3)"` alongside real items.
- Root cause: `has_bp_section()` in the Blueprint Tracker's matching layer (`blueprint_meta.py`) ran on **every entry's value unconditionally**, regardless of category. Commodity items (e.g. raw ores) get a separate, independently-renameable "Blueprint Data" section listing what they're used to craft. If that header text collides with the mission "Blueprints" header (e.g. both left at/set to the same text), the commodity's crafting-material-usage summary gets scanned as if it were a real mission's blueprint reward list -- fabricating fake, unownable "items" indistinguishable from real ones in both Available and Owned.
- Fix: gated blueprint-bullet scanning to `category == "Missions"` entries only, since a real POTENTIAL BLUEPRINTS section never legitimately exists anywhere else. Applied consistently to both the Blueprint Tracker's matching (`blueprint_meta.py`) and the String Editor's "BP Descriptions" filter (`entry_filter.py`), which had the identical unscoped check.
- Every existing test with blueprint-bearing content already used `category="Missions"` in its fixtures, confirming this gate matches the codebase's own intent -- it just wasn't enforced in code yet.

## Test plan
- [x] Full test suite: 1577 passed, 0 failed (`pytest -q`)
- [x] New coverage: a commodity entry whose value contains a colliding "POTENTIAL BLUEPRINTS"-shaped header is confirmed excluded from both `build_blueprint_metadata()`'s output and the String Editor's "BP Descriptions" filter.
- [x] Manual portable build test: reproduced the exact collision (set "Blueprint data" to the same text as "Blueprints", left everything else at default) and confirmed the tracker no longer stacks fake entries, while real mission-derived blueprints continue to populate normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
