### PR TITLE
Fix Blueprint Tracker ignoring a renamed "blueprints" mission header (#353)

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1728,7 +1728,7 @@ class MainWindow(QMainWindow):
             _owned = AppSettings.get_owned_items()
             if _owned:
                 from src.utils.owned_items import apply_owned_to_value
-                _bp_header = AppSettings.get_mission_headers().get("blueprints")
+                _bp_header = self._bp_header()
                 for _k, _v in list(merged_dict.items()):
                     _nv = apply_owned_to_value(_v, _owned, bp_header=_bp_header)
                     if _nv != _v:
@@ -4996,7 +4996,7 @@ class MainWindow(QMainWindow):
             bp_titles_only=self.bp_titles_check.isChecked(),
             bp_descs_only=self.bp_descs_check.isChecked(),
             ship_vehicle_names_only=self.ship_vehicle_names_only_check.isChecked(),
-            bp_header=AppSettings.get_mission_headers().get("blueprints"),
+            bp_header=self._bp_header(),
         )
 
     @timed
@@ -5278,6 +5278,24 @@ class MainWindow(QMainWindow):
         self.table.setCurrentIndex(custom_index)
         self.table.edit(custom_index)
 
+    def _bp_header(self) -> "str | None":
+        """The user's configured "blueprints" mission header, or None when it
+        has never been renamed (#353).
+
+        Every matcher that has to recognise a blueprint section needs this, and
+        all of them must agree: the metadata scan, the owned re-weave, the
+        String Editor's BP filter, and the Apply-to-Game write path. Reading it
+        through one accessor is what keeps a fifth caller from being added with
+        a different key by mistake.
+
+        Read fresh on every call rather than cached. The header is editable in
+        the Enhancements tab mid-session, so a cached copy would need
+        invalidating from that edit, and a stale one means the tracker quietly
+        stops matching the text the generator is now writing. The read is a
+        settings lookup on paths that already do far more work than that.
+        """
+        return AppSettings.get_mission_headers().get("blueprints")
+
     def _rebuild_blueprint_metadata(self):
         """#157 follow-up: scan loaded strings once to build the blueprint-item
         metadata (eligible names + per-item mission/type/class/size/grade) the
@@ -5285,7 +5303,7 @@ class MainWindow(QMainWindow):
         it runs on load — not on every owned-toggle (that path re-partitions
         the cached result)."""
         from src.utils.blueprint_meta import build_blueprint_metadata
-        bp_header = AppSettings.get_mission_headers().get("blueprints")
+        bp_header = self._bp_header()
         self._blueprint_meta = build_blueprint_metadata(self.entries, bp_header=bp_header)
         self._bp_item_names = set(self._blueprint_meta)
 
@@ -5296,7 +5314,7 @@ class MainWindow(QMainWindow):
         the tag. The eligible-name set + filter metadata are built separately by
         `_rebuild_blueprint_metadata` (cached, not rescanned here)."""
         from src.utils.owned_items import apply_owned_to_value
-        bp_header = AppSettings.get_mission_headers().get("blueprints")
+        bp_header = self._bp_header()
         owned = AppSettings.get_owned_items()
         for e in self.entries:
             new_val = apply_owned_to_value(e.original_value, owned, bp_header=bp_header)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1728,8 +1728,9 @@ class MainWindow(QMainWindow):
             _owned = AppSettings.get_owned_items()
             if _owned:
                 from src.utils.owned_items import apply_owned_to_value
+                _bp_header = AppSettings.get_mission_headers().get("blueprints")
                 for _k, _v in list(merged_dict.items()):
-                    _nv = apply_owned_to_value(_v, _owned)
+                    _nv = apply_owned_to_value(_v, _owned, bp_header=_bp_header)
                     if _nv != _v:
                         merged_dict[_k] = _nv
 
@@ -4995,6 +4996,7 @@ class MainWindow(QMainWindow):
             bp_titles_only=self.bp_titles_check.isChecked(),
             bp_descs_only=self.bp_descs_check.isChecked(),
             ship_vehicle_names_only=self.ship_vehicle_names_only_check.isChecked(),
+            bp_header=AppSettings.get_mission_headers().get("blueprints"),
         )
 
     @timed
@@ -5283,7 +5285,8 @@ class MainWindow(QMainWindow):
         it runs on load — not on every owned-toggle (that path re-partitions
         the cached result)."""
         from src.utils.blueprint_meta import build_blueprint_metadata
-        self._blueprint_meta = build_blueprint_metadata(self.entries)
+        bp_header = AppSettings.get_mission_headers().get("blueprints")
+        self._blueprint_meta = build_blueprint_metadata(self.entries, bp_header=bp_header)
         self._bp_item_names = set(self._blueprint_meta)
 
     def _recompute_owned(self):
@@ -5293,9 +5296,10 @@ class MainWindow(QMainWindow):
         the tag. The eligible-name set + filter metadata are built separately by
         `_rebuild_blueprint_metadata` (cached, not rescanned here)."""
         from src.utils.owned_items import apply_owned_to_value
+        bp_header = AppSettings.get_mission_headers().get("blueprints")
         owned = AppSettings.get_owned_items()
         for e in self.entries:
-            new_val = apply_owned_to_value(e.original_value, owned)
+            new_val = apply_owned_to_value(e.original_value, owned, bp_header=bp_header)
             if new_val != e.original_value:
                 e.original_value = new_val
         self._model.set_owned_state(self._bp_item_names, owned)

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -436,13 +436,22 @@ def _title_pair_key(base: str, num) -> tuple:
     return (base.lower(), num or "")
 
 
-def build_blueprint_metadata(entries) -> dict:
+def build_blueprint_metadata(
+    entries, bp_header: "str | None" = None
+) -> dict:
     """Scan loaded strings once and return ``{name: BlueprintItem}``.
 
     *entries* is any iterable of objects exposing ``key`` / ``original_value``
     / ``category``. The result is keyed by the same normalized item names the
     owned set and ``StringTableModel`` use, so it drops straight into the
     Blueprints shuttle.
+
+    ``bp_header``, when given, is the user's actual configured "blueprints"
+    mission header (#353) -- e.g. ``AppSettings.get_mission_headers()
+    ["blueprints"]``. Without it, a renamed header is never recognized as a
+    blueprint-bearing section at all, so the Pass 1 gate below silently
+    skips every mission, not just mis-tags one. See
+    ``owned_items.has_bp_section``'s docstring.
     """
     # Pass 1: name->key map (for type), component tag attrs, mission titles,
     # and the blueprint-bearing desc values.
@@ -496,7 +505,7 @@ def build_blueprint_metadata(entries) -> dict:
             titles[_title_pair_key(tm.group("base"), tm.group("num"))] = \
                 clean_mission_title(val)
 
-        if has_bp_section(val):
+        if has_bp_section(val, bp_header):
             dm = _DESC_KEY_RE.match(key)
             pair = _title_pair_key(dm.group("base"), dm.group("num")) if dm else None
             bp_descs.append((pair, val))
@@ -511,7 +520,7 @@ def build_blueprint_metadata(entries) -> dict:
     missions_by_name: dict = {}
     for pair, val in bp_descs:
         title = titles.get(pair) if pair else None
-        for raw_nm in extract_bp_item_names(val):
+        for raw_nm in extract_bp_item_names(val, bp_header):
             if raw_nm in name_to_value:
                 nm = raw_nm
             elif raw_nm in _BULLET_NAME_ALIASES:

--- a/src/utils/entry_filter.py
+++ b/src/utils/entry_filter.py
@@ -26,6 +26,7 @@ def filter_entry_indices(
     bp_titles_only: bool = False,
     bp_descs_only: bool = False,
     ship_vehicle_names_only: bool = False,
+    bp_header: "str | None" = None,
 ) -> list[int]:
     """Return indices of entries that pass all active filters.
 
@@ -52,6 +53,9 @@ def filter_entry_indices(
         bp_descs_only: When True, keep mission-description rows containing the
             POTENTIAL BLUEPRINTS section (#156). When both bp_* flags are set
             the row passes if it matches EITHER (blueprint titles OR bodies).
+        bp_header: The user's actual configured "blueprints" mission header
+            (#353), e.g. AppSettings.get_mission_headers()["blueprints"].
+            Without it, a renamed header is never recognized here either.
         ship_vehicle_names_only: When True, show ONLY ship/vehicle name rows
             (vehicle_Name*, Wikelo *_VehicleName) -- every other row is
             hidden, including ship description rows and every non-Ships
@@ -130,7 +134,7 @@ def filter_entry_indices(
         if bp_titles_only or bp_descs_only:
             val = entry.custom_value or entry.original_value
             is_bp_title = bp_titles_only and "[BP" in val
-            is_bp_desc = bp_descs_only and has_bp_section(val)
+            is_bp_desc = bp_descs_only and has_bp_section(val, bp_header)
             if not (is_bp_title or is_bp_desc):
                 continue
         if active_filter_fns:

--- a/src/utils/owned_items.py
+++ b/src/utils/owned_items.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import re
 import unicodedata
+from functools import lru_cache
 
 # The bullet line separator inside a stored INI value (literal backslash-n).
 _NL = "\\n"
@@ -115,13 +116,48 @@ BULLET_NAME_ALIASES: dict[str, str] = {
 # Tracker altogether, regardless of any per-item fix.
 _ALT_BP_SECTION_HEADER = "MULTIPLE BLUEPRINT POOLS"
 BP_SECTION_HEADER = "POTENTIAL BLUEPRINTS"
-_BP_HEADER_RE = re.compile(
-    "(?:" + re.escape(BP_SECTION_HEADER) + "|" + re.escape(_ALT_BP_SECTION_HEADER) + ")",
-    re.IGNORECASE,
-)
 
 
-def has_bp_section(value: str) -> bool:
+@lru_cache(maxsize=8)
+def _build_bp_header_re(custom_header: "str | None"):
+    """Compiled header-matching regex, optionally widened to ALSO recognize
+    *custom_header* -- the user's actual configured "blueprints" mission
+    header (AppSettings.get_mission_headers()["blueprints"]), which the
+    generator writes verbatim into mission text instead of the hardcoded
+    default when the user has renamed it (#353). Without this, has_bp_section
+    /_bp_section_span never matched a renamed header at all, so the Blueprint
+    Tracker silently stopped scanning every mission -- not just mis-tagging
+    one, the whole feature going dark for anyone who renamed this header.
+
+    Anchored to an ``<EM3>``/``<EM4>`` wrapper (matching open/close tag
+    number, like _SECTION_HEADER_RE below), not a bare substring search: the
+    generator always writes the header as ``f"<{em}>{header}</{em}>"``
+    (generate_enhancements_ini.py), so requiring that wrapper here too rules
+    out an unrelated, coincidental occurrence of the header text elsewhere in
+    the SAME mission's own prose. This matters far more once the header is
+    user-renameable -- "POTENTIAL BLUEPRINTS" is distinctive enough to never
+    collide with real flavor text by accident, but a user-chosen replacement
+    (a real report: renamed to "stuff") can easily be an ordinary word CIG's
+    own mission dialogue already uses elsewhere in the same body, which the
+    old bare-substring match would treat as the section start and sweep every
+    stray "\\n- <word>" prose bullet between that false match and the real
+    header (or next section) into the item set as if they were blueprints.
+
+    *custom_header* is skipped (falls back to the module-level default-only
+    pattern) when empty or already equal to one of the built-in headers, so
+    the common "never renamed it" case doesn't pay for an extra regex build.
+    Cached because this can be called once per entry across a full rescan.
+    """
+    parts = [BP_SECTION_HEADER, _ALT_BP_SECTION_HEADER]
+    if custom_header:
+        custom_header = custom_header.strip()
+        if custom_header and custom_header.upper() not in {p.upper() for p in parts}:
+            parts.append(custom_header)
+    alt = "|".join(re.escape(p) for p in parts)
+    return re.compile(r"<EM([34])>\s*(?:" + alt + r")\s*</EM\1>", re.IGNORECASE)
+
+
+def has_bp_section(value: str, bp_header: "str | None" = None) -> bool:
     """True if *value* contains a recognised blueprint-section header.
 
     Single source of truth for the "is this a blueprint-bearing mission
@@ -130,8 +166,13 @@ def has_bp_section(value: str) -> bool:
     Descriptions" checkbox) -- both used to do their own raw ``BP_SECTION_
     HEADER in value.upper()`` substring check, which missed the
     "MULTIPLE BLUEPRINT POOLS" header entirely.
+
+    ``bp_header``, when given, is the user's actual configured "blueprints"
+    mission header (#353) -- see :func:`_build_bp_header_re`. Defaults to
+    matching only the built-in headers when omitted, matching this
+    function's original hardcoded behavior exactly.
     """
-    return bool(_BP_HEADER_RE.search(value or ""))
+    return bool(_build_bp_header_re(bp_header).search(value or ""))
 
 
 # A tag that MIGHT be a genuine section header (POTENTIAL BLUEPRINTS, ITEM
@@ -156,11 +197,12 @@ _AWARDED_FROM_RE = re.compile(r"^awarded from .+ variants$", re.IGNORECASE)
 _POOL_LABEL_RE = re.compile(r"^pool \d+$", re.IGNORECASE)
 
 
-def _bp_section_span(value: str):
+def _bp_section_span(value: str, bp_header: "str | None" = None):
     """Return (start, end) spanning just the blueprint section's bullet
     content — from right after its header (POTENTIAL BLUEPRINTS or MULTIPLE
-    BLUEPRINT POOLS) up to the next real section header (or end of string).
-    ``None`` when there's no such section.
+    BLUEPRINT POOLS, or the user's renamed header -- see :func:`has_bp_
+    section`) up to the next real section header (or end of string). ``None``
+    when there's no such section.
 
     Bounding the scan this way matters: CIG mission bodies sometimes carry a
     stray "\\n- <word>" line in the flavor-text prose *before* the header
@@ -171,8 +213,13 @@ def _bp_section_span(value: str):
     section are pooled into a single set -- this module doesn't track which
     specific pool/tier a bullet belongs to, matching the pre-existing
     region-label behaviour.
+
+    The END boundary doesn't need ``bp_header`` awareness even if the user
+    also renamed "MISSION DETAILS"/"ITEM REWARDS"/etc: the loop below treats
+    ANY other ``<EM3>``/``<EM4>`` tag as the next section's start regardless
+    of its specific text, so a renamed header there is already handled.
     """
-    m = _BP_HEADER_RE.search(value)
+    m = _build_bp_header_re(bp_header).search(value)
     if not m:
         return None
     start = m.end()
@@ -222,17 +269,18 @@ def normalize_item_name(name: str) -> str:
     return BULLET_NAME_ALIASES.get(s, s)
 
 
-def extract_bp_item_names(value: str) -> set[str]:
+def extract_bp_item_names(value: str, bp_header: "str | None" = None) -> set[str]:
     """Return the normalized item names in *value*'s POTENTIAL BLUEPRINTS list.
 
     Empty when the value has no such section. Scoped to just that section's
     span (see :func:`_bp_section_span`) so a stray prose bullet before the
     header or a real bullet in a later section (ITEM REWARDS, ...) isn't
-    picked up as a blueprint item.
+    picked up as a blueprint item. ``bp_header`` is forwarded to
+    :func:`_bp_section_span` -- see :func:`has_bp_section`'s docstring (#353).
     """
     if not value:
         return set()
-    span = _bp_section_span(value)
+    span = _bp_section_span(value, bp_header)
     if span is None:
         return set()
     start, end = span
@@ -241,7 +289,9 @@ def extract_bp_item_names(value: str) -> set[str]:
             if normalize_item_name(m.group(1))}
 
 
-def apply_owned_to_value(value: str, owned: set[str]) -> str:
+def apply_owned_to_value(
+    value: str, owned: set[str], bp_header: "str | None" = None
+) -> str:
     """Return *value* with ``[Owned]`` on bullets whose item is in *owned*.
 
     Idempotent: any existing ``[Owned]`` tag is removed first, so the result is
@@ -250,7 +300,8 @@ def apply_owned_to_value(value: str, owned: set[str]) -> str:
     stripping stale owned tags, in case an item was just un-owned). Retagging
     is scoped to just that section's span (see :func:`_bp_section_span`) so a
     stray prose bullet before the header or a bullet in a later section can
-    never be mistaken for a blueprint item.
+    never be mistaken for a blueprint item. ``bp_header`` is forwarded to
+    :func:`_bp_section_span` -- see :func:`has_bp_section`'s docstring (#353).
     """
     if not value:
         return value
@@ -258,7 +309,7 @@ def apply_owned_to_value(value: str, owned: set[str]) -> str:
     value = _OWNED_STRIP_RE.sub("", value)
     if not owned:
         return value
-    span = _bp_section_span(value)
+    span = _bp_section_span(value, bp_header)
     if span is None:
         return value
     start, end = span

--- a/src/utils/owned_items.py
+++ b/src/utils/owned_items.py
@@ -154,7 +154,21 @@ def _build_bp_header_re(custom_header: "str | None"):
         if custom_header and custom_header.upper() not in {p.upper() for p in parts}:
             parts.append(custom_header)
     alt = "|".join(re.escape(p) for p in parts)
-    return re.compile(r"<EM([34])>\s*(?:" + alt + r")\s*</EM\1>", re.IGNORECASE)
+    # A trailing parenthesised qualifier is part of the header, not a
+    # different header. CIG ships several: "Potential Blueprints (Repeat
+    # Only)", "(BitZeros Only)", "(Nyx Only)", "(Pyro IV/V Area Only)", and
+    # "Multiple Blueprint Pools (Yormandi Eye Only)" -- 20 lines across the
+    # 292 header-bearing lines in tests/fixtures/kraken_global_latest.ini.
+    # Requiring the wrapper to hold *only* the header text dropped every one
+    # of them, which is the same "mission silently absent from the tracker"
+    # failure this function exists to fix, just for a different subset. The
+    # group stays optional and bounded to one parenthesised run, so it still
+    # rejects unrelated text: "<EM3>stuffed animals</EM3>" does not match a
+    # header renamed to "stuff".
+    return re.compile(
+        r"<EM([34])>\s*(?:" + alt + r")(?:\s*\([^)]*\))?\s*</EM\1>",
+        re.IGNORECASE,
+    )
 
 
 def has_bp_section(value: str, bp_header: "str | None" = None) -> bool:

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -297,6 +297,26 @@ def test_item_in_multiple_missions_unions_titles():
     assert meta["Balandin"].missions == frozenset({"First Job", "Second Job"})
 
 
+def test_renamed_blueprints_header_recognized_when_bp_header_passed():
+    """#353: a user-renamed "blueprints" mission header must still populate
+    the Blueprint Tracker when the actual configured header is passed
+    through -- without it, every mission using the renamed header was
+    silently unscanned, not just mis-tagged."""
+    desc = "x\\n<EM4>MY LOOT</EM4>\\n- Antium Core"
+    meta = build_blueprint_metadata(
+        [_Entry("M_Desc_001", desc, "Missions")], bp_header="MY LOOT"
+    )
+    assert "Antium Core" in meta
+
+
+def test_renamed_blueprints_header_not_recognized_without_bp_header():
+    """Regression guard: omitting bp_header must behave exactly like the
+    original hardcoded-default-only implementation."""
+    desc = "x\\n<EM4>MY LOOT</EM4>\\n- Antium Core"
+    meta = build_blueprint_metadata([_Entry("M_Desc_001", desc, "Missions")])
+    assert "Antium Core" not in meta
+
+
 def test_desc_without_title_yields_no_mission_but_keeps_item():
     desc = "x\\n<EM4>POTENTIAL BLUEPRINTS</EM4>\\n- Orphan Part"
     meta = build_blueprint_metadata([_Entry("Loose_Desc_001", desc, "Missions")])

--- a/tests/test_owned_items.py
+++ b/tests/test_owned_items.py
@@ -141,6 +141,48 @@ class TestExtract:
     def test_empty_value(self):
         assert extract_bp_item_names("") == set()
 
+    # -- #353: renamed "blueprints" mission header ---------------------------
+
+    def test_renamed_header_not_recognized_by_default(self):
+        """Regression guard: without bp_header, a renamed header is invisible
+        -- pins the pre-fix behavior so the fix below is a real change."""
+        renamed = _DESC.replace("POTENTIAL BLUEPRINTS", "MY LOOT")
+        assert extract_bp_item_names(renamed) == set()
+
+    def test_renamed_header_recognized_when_bp_header_passed(self):
+        renamed = _DESC.replace("POTENTIAL BLUEPRINTS", "MY LOOT")
+        names = extract_bp_item_names(renamed, bp_header="MY LOOT")
+        assert names == {"Antium Core", "Norfield", "Abrade Scraper Module"}
+
+    def test_bp_header_matching_is_case_insensitive(self):
+        renamed = _DESC.replace("POTENTIAL BLUEPRINTS", "my loot")
+        names = extract_bp_item_names(renamed, bp_header="My Loot")
+        assert names == {"Antium Core", "Norfield", "Abrade Scraper Module"}
+
+    def test_bp_header_still_recognizes_default_when_not_renamed(self):
+        """Passing bp_header must not stop the built-in default from still
+        working for missions that never got regenerated since the rename."""
+        names = extract_bp_item_names(_DESC, bp_header="MY LOOT")
+        assert names == {"Antium Core", "Norfield", "Abrade Scraper Module"}
+
+    def test_renamed_header_word_appearing_unwrapped_in_prose_is_not_a_false_positive(self):
+        """Real report: renaming the header to a short/common word ("stuff")
+        let it accidentally match an unrelated, unwrapped occurrence of that
+        same word elsewhere in the mission's own prose (a stray "- <name>"
+        bullet list), starting the scan window too early and sweeping
+        unrelated prose bullets ("Ed", "H", "Wallace", ...) into the item
+        set as if they were real blueprints. The header match must be
+        anchored to the actual <EM3>/<EM4> wrapper the generator always uses
+        (see _build_bp_header_re), not a bare substring search, so an
+        earlier unwrapped occurrence of the same text is correctly ignored.
+        """
+        desc = (
+            "Grab that stuff for me.\\n- Ed\\n- H\\n- Wallace"
+            "\\n\\n<EM3>stuff</EM3>\\n- Antium Core"
+        )
+        names = extract_bp_item_names(desc, bp_header="stuff")
+        assert names == {"Antium Core"}
+
     def test_excludes_prose_bullet_before_header_and_later_section_bullet(self):
         """A stray "- Stows" line in the mission's flavor-text prose (before
         the POTENTIAL BLUEPRINTS header) and a real bullet in a later ITEM
@@ -290,7 +332,7 @@ class TestApply:
         # #222: a bullet carrying a non-breaking space or a trailing component
         # tag still matches an owned entry stored in bare/plain form.
         nl = chr(92) + "n"
-        val = ("POTENTIAL BLUEPRINTS" + nl + "- Lynx" + chr(0xA0) + "Legs"
+        val = ("<EM3>POTENTIAL BLUEPRINTS</EM3>" + nl + "- Lynx" + chr(0xA0) + "Legs"
                + nl + "- Barbican [IND-S3-B]" + nl + "- Norfield")
         out = apply_owned_to_value(val, {"Lynx Legs", "Barbican"})
         assert out.count("<EM4>[Owned]</EM4>") == 2

--- a/tests/test_owned_items.py
+++ b/tests/test_owned_items.py
@@ -183,6 +183,67 @@ class TestExtract:
         names = extract_bp_item_names(desc, bp_header="stuff")
         assert names == {"Antium Core"}
 
+    # CIG qualifies its own headers, and every one of these appears in
+    # tests/fixtures/kraken_global_latest.ini. Anchoring the match to an
+    # <EM3>/<EM4> wrapper that may hold ONLY the header text dropped all of
+    # them (20 of the fixture's 292 header-bearing lines), which is the same
+    # "mission silently absent from the Blueprint Tracker" failure #353 is
+    # about, just for a different subset. Every hand-written test above still
+    # passed, because none of them used a real CIG header.
+    @pytest.mark.parametrize("header_text", [
+        "Potential Blueprints (Repeat Only)",
+        "Potential Blueprints (BitZeros Only)",
+        "Potential Blueprints (Nyx Only)",
+        "Potential Blueprints (Pyro IV/V Area Only)",
+        "Multiple Blueprint Pools (Repeat Only)",
+        "Multiple Blueprint Pools (Yormandi Eye Only)",
+    ])
+    def test_cig_qualified_headers_are_recognized(self, header_text):
+        nl = chr(92) + "n"
+        val = f"flavor text{nl}<EM4>{header_text}</EM4>{nl}- Antium Core"
+        assert extract_bp_item_names(val) == {"Antium Core"}
+
+    def test_qualifier_tolerance_does_not_admit_unrelated_wrapped_text(self):
+        """The optional qualifier must stay bounded to a parenthesised run, or
+        it would undo the very false-positive guard the wrapper anchor exists
+        for: a header renamed to a common word must not match prose that
+        merely starts with it."""
+        nl = chr(92) + "n"
+        val = f"x{nl}<EM3>stuffed animals</EM3>{nl}- Antium Core"
+        assert extract_bp_item_names(val, bp_header="stuff") == set()
+
+    def test_fixture_header_recognition_matches_bare_substring_search(self):
+        """Parity guard against the real CIG data.
+
+        The regression this pins was invisible to every hand-written case, so
+        it is checked against the shipped fixture instead: whatever the
+        anchored pattern does, it must not recognise FEWER header-bearing
+        lines than a naive substring search for the two built-in headers.
+        """
+        import re
+        from pathlib import Path
+        # Same `utils.` import path this module already uses at the top --
+        # `utils.owned_items` and `src.utils.owned_items` are distinct module
+        # objects under this repo's dual pythonpath.
+        from utils.owned_items import (
+            _ALT_BP_SECTION_HEADER, _build_bp_header_re, BP_SECTION_HEADER,
+        )
+
+        fixture = Path(__file__).parent / "fixtures" / "kraken_global_latest.ini"
+        if not fixture.exists():                       # optional large fixture
+            pytest.skip("kraken_global_latest.ini not present")
+        lines = [l for l in fixture.read_text(encoding="utf-8", errors="replace")
+                 .splitlines() if "=" in l]
+        bare = re.compile(
+            "(?:" + re.escape(BP_SECTION_HEADER) + "|"
+            + re.escape(_ALT_BP_SECTION_HEADER) + ")", re.IGNORECASE)
+        anchored = _build_bp_header_re(None)
+        missed = [l for l in lines if bare.search(l) and not anchored.search(l)]
+        assert not missed, (
+            f"{len(missed)} header-bearing lines in the real fixture are no "
+            f"longer recognised, e.g. {missed[0][:160]!r}"
+        )
+
     def test_excludes_prose_bullet_before_header_and_later_section_bullet(self):
         """A stray "- Stows" line in the mission's flavor-text prose (before
         the POTENTIAL BLUEPRINTS header) and a real bullet in a later ITEM


### PR DESCRIPTION
Fixes #353.

## Summary
- Reported: renaming the mission "Blueprints" section header (Config > Mission Labels) silently breaks the Blueprint Tracker -- it stops populating entirely, not just mis-tagging.
- Root cause: the generator writes the user's actual configured header text into mission bodies instead of the hardcoded default, but `has_bp_section`/`_bp_section_span` (the "is this a blueprint-bearing mission body" gate) only ever recognized the literal `"POTENTIAL BLUEPRINTS"` default.
- Fix: thread the real configured header (`AppSettings.get_mission_headers()["blueprints"]`) through the matching layer -- `owned_items.py`'s `has_bp_section`/`_bp_section_span`/`extract_bp_item_names`/`apply_owned_to_value`, `blueprint_meta.py`'s `build_blueprint_metadata`, and `entry_filter.py`'s "BP Descriptions" filter -- mirroring the pattern already used for #352's configurable enclosing style.
- **Follow-up fix found during manual testing:** the header match must be anchored to the actual `<EM3>`/`<EM4>` wrapper the generator always uses (`f"<{em}>{header}</{em}>"`), not a bare substring search anywhere in the mission body. `"POTENTIAL BLUEPRINTS"` is distinctive enough to never collide with real mission flavor text by accident, but a user-renamed header can easily be an ordinary word -- reported case: renamed to `"stuff"`, which already appeared as plain prose earlier in the same mission body (a stray NPC/contact name list: "Ed", "H", "Wallace", ...). The old unanchored match found that earlier, unwrapped occurrence and started the blueprint-bullet scan from there, sweeping those unrelated names into the item set as if they were real blueprints. Anchoring to the properly-tagged header closes this.

## Test plan
- [x] Full test suite: **1629 passed, 21 skipped, 0 failed** (`pytest -q`) - re-run after the #356 merge landed on this branch
- [x] New coverage: renamed-header recognition (with and without the `bp_header` param, case-insensitivity, default-still-works-when-not-renamed), and a direct regression test reproducing the reported collision (a renamed header word appearing unwrapped in prose earlier in the same mission body, followed by the real EM-wrapped header).
- [x] Manual portable build test, two rounds: first round reproduced the "stuff" collision bug live; second round (after the anchoring fix) confirmed the fake entries are gone and the Blueprint Tracker populates correctly with a fully renamed header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

