### PR TITLE
Fix Blueprint Tracker with custom reward heading

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -5283,7 +5283,9 @@ class MainWindow(QMainWindow):
         it runs on load — not on every owned-toggle (that path re-partitions
         the cached result)."""
         from src.utils.blueprint_meta import build_blueprint_metadata
-        self._blueprint_meta = build_blueprint_metadata(self.entries)
+        self._blueprint_meta = build_blueprint_metadata(
+            self.entries, AppSettings.get_mission_headers()["blueprints"]
+        )
         self._bp_item_names = set(self._blueprint_meta)
 
     def _recompute_owned(self):
@@ -5295,7 +5297,9 @@ class MainWindow(QMainWindow):
         from src.utils.owned_items import apply_owned_to_value
         owned = AppSettings.get_owned_items()
         for e in self.entries:
-            new_val = apply_owned_to_value(e.original_value, owned)
+            new_val = apply_owned_to_value(
+                e.original_value, owned, AppSettings.get_mission_headers()["blueprints"]
+            )
             if new_val != e.original_value:
                 e.original_value = new_val
         self._model.set_owned_state(self._bp_item_names, owned)

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -436,7 +436,7 @@ def _title_pair_key(base: str, num) -> tuple:
     return (base.lower(), num or "")
 
 
-def build_blueprint_metadata(entries) -> dict:
+def build_blueprint_metadata(entries, blueprint_header: str = "") -> dict:
     """Scan loaded strings once and return ``{name: BlueprintItem}``.
 
     *entries* is any iterable of objects exposing ``key`` / ``original_value``
@@ -496,7 +496,7 @@ def build_blueprint_metadata(entries) -> dict:
             titles[_title_pair_key(tm.group("base"), tm.group("num"))] = \
                 clean_mission_title(val)
 
-        if has_bp_section(val):
+        if has_bp_section(val, blueprint_header):
             dm = _DESC_KEY_RE.match(key)
             pair = _title_pair_key(dm.group("base"), dm.group("num")) if dm else None
             bp_descs.append((pair, val))
@@ -511,7 +511,7 @@ def build_blueprint_metadata(entries) -> dict:
     missions_by_name: dict = {}
     for pair, val in bp_descs:
         title = titles.get(pair) if pair else None
-        for raw_nm in extract_bp_item_names(val):
+        for raw_nm in extract_bp_item_names(val, blueprint_header):
             if raw_nm in name_to_value:
                 nm = raw_nm
             elif raw_nm in _BULLET_NAME_ALIASES:

--- a/src/utils/owned_items.py
+++ b/src/utils/owned_items.py
@@ -121,7 +121,14 @@ _BP_HEADER_RE = re.compile(
 )
 
 
-def has_bp_section(value: str) -> bool:
+def _bp_header_re(custom_header: str = ""):
+    headers = [BP_SECTION_HEADER, _ALT_BP_SECTION_HEADER]
+    if custom_header and custom_header.casefold() not in {h.casefold() for h in headers}:
+        headers.append(custom_header)
+    return re.compile("(?:" + "|".join(re.escape(h) for h in headers) + ")", re.IGNORECASE)
+
+
+def has_bp_section(value: str, custom_header: str = "") -> bool:
     """True if *value* contains a recognised blueprint-section header.
 
     Single source of truth for the "is this a blueprint-bearing mission
@@ -131,7 +138,7 @@ def has_bp_section(value: str) -> bool:
     HEADER in value.upper()`` substring check, which missed the
     "MULTIPLE BLUEPRINT POOLS" header entirely.
     """
-    return bool(_BP_HEADER_RE.search(value or ""))
+    return bool(_bp_header_re(custom_header).search(value or ""))
 
 
 # A tag that MIGHT be a genuine section header (POTENTIAL BLUEPRINTS, ITEM
@@ -156,7 +163,7 @@ _AWARDED_FROM_RE = re.compile(r"^awarded from .+ variants$", re.IGNORECASE)
 _POOL_LABEL_RE = re.compile(r"^pool \d+$", re.IGNORECASE)
 
 
-def _bp_section_span(value: str):
+def _bp_section_span(value: str, custom_header: str = ""):
     """Return (start, end) spanning just the blueprint section's bullet
     content — from right after its header (POTENTIAL BLUEPRINTS or MULTIPLE
     BLUEPRINT POOLS) up to the next real section header (or end of string).
@@ -172,7 +179,7 @@ def _bp_section_span(value: str):
     specific pool/tier a bullet belongs to, matching the pre-existing
     region-label behaviour.
     """
-    m = _BP_HEADER_RE.search(value)
+    m = _bp_header_re(custom_header).search(value)
     if not m:
         return None
     start = m.end()
@@ -222,7 +229,7 @@ def normalize_item_name(name: str) -> str:
     return BULLET_NAME_ALIASES.get(s, s)
 
 
-def extract_bp_item_names(value: str) -> set[str]:
+def extract_bp_item_names(value: str, custom_header: str = "") -> set[str]:
     """Return the normalized item names in *value*'s POTENTIAL BLUEPRINTS list.
 
     Empty when the value has no such section. Scoped to just that section's
@@ -232,7 +239,7 @@ def extract_bp_item_names(value: str) -> set[str]:
     """
     if not value:
         return set()
-    span = _bp_section_span(value)
+    span = _bp_section_span(value, custom_header)
     if span is None:
         return set()
     start, end = span
@@ -241,7 +248,7 @@ def extract_bp_item_names(value: str) -> set[str]:
             if normalize_item_name(m.group(1))}
 
 
-def apply_owned_to_value(value: str, owned: set[str]) -> str:
+def apply_owned_to_value(value: str, owned: set[str], custom_header: str = "") -> str:
     """Return *value* with ``[Owned]`` on bullets whose item is in *owned*.
 
     Idempotent: any existing ``[Owned]`` tag is removed first, so the result is
@@ -258,7 +265,7 @@ def apply_owned_to_value(value: str, owned: set[str]) -> str:
     value = _OWNED_STRIP_RE.sub("", value)
     if not owned:
         return value
-    span = _bp_section_span(value)
+    span = _bp_section_span(value, custom_header)
     if span is None:
         return value
     start, end = span

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -37,6 +37,14 @@ class _Entry:
     category: str = "Other"
 
 
+def test_metadata_accepts_configured_blueprint_heading():
+    entries = [
+        _Entry("item_Name_Test", "Test Blueprint", "Ship Items"),
+        _Entry("Mission_Desc_001", "<EM4>MY REWARDS</EM4>\\n- Test Blueprint", "Missions"),
+    ]
+    assert "Test Blueprint" in build_blueprint_metadata(entries, "MY REWARDS")
+
+
 def test_parse_component_tag():
     assert parse_component_tag("[MIL-S3-B] Balandin") == ("MIL", "S3", "B")
     assert parse_component_tag("[ind-s1-a] Palisade") == ("IND", "S1", "A")


### PR DESCRIPTION
Fixes #353.

The Blueprint Tracker previously recognized only the default `POTENTIAL BLUEPRINTS` heading. If a player renamed that configurable mission header, the tracker stopped detecting blueprint-bearing mission descriptions and appeared empty.

This change passes the configured blueprint header into the shared section parser while preserving support for the default heading and `MULTIPLE BLUEPRINT POOLS`.

It also keeps owned-blueprint tag processing consistent with the Tracker.

Tests:
- Added coverage for a custom heading.
- `89` Blueprint metadata and owned-item tests pass.