### PR TITLE
Fix Yormandi Eye and Irradiated Valakkar Pearl blueprint lists merging together

### DIFF
--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -3151,7 +3151,7 @@ def _merge_blueprint_pool(
 # plumbing is needed -- just what's already visible in the rendered list.
 # Add entries here as more ambiguous multi-pool missions are found; any
 # pool not listed keeps the automatic "first item" naming below.
-_BLUEPRINT_POOL_LABEL_OVERRIDES: dict[frozenset, str] = {
+_BLUEPRINT_POOL_LABEL_OVERRIDES: dict[frozenset[str], str] = {
     frozenset({
         "P8-AR Rifle", "P8-AR Rifle Magazine (15 Cap)",
         "Palatino Arms", "Palatino Arms Moonfall",
@@ -3166,6 +3166,42 @@ _BLUEPRINT_POOL_LABEL_OVERRIDES: dict[frozenset, str] = {
         "Stirling Exploration Suit",
     }): "Irradiated Valakkar Pearls",
 }
+
+# Overlap threshold (fraction of the smaller set) for _warn_if_near_override_miss
+# below -- deliberately conservative so unrelated pools that just happen to
+# share a couple of item names (e.g. a common battery/magazine) don't trigger
+# a false-positive warning on every generation run.
+_OVERRIDE_DRIFT_OVERLAP_THRESHOLD = 0.7
+
+
+def _warn_if_near_override_miss(fp_items: frozenset[str]) -> None:
+    """Log a warning if *fp_items* closely overlaps a known override's item
+    set without exactly matching it.
+
+    The override table (above) matches on exact item-set equality, so if
+    CIG adds, removes, or renames an item in a pool it's tracking, the
+    override silently stops applying with no error -- the section just
+    reverts to auto-generated naming. That's a reasonable failure mode for
+    an end user, but it leaves a maintainer with no signal that the table
+    needs updating. This is a cheap heuristic tripwire for exactly that:
+    if a pool shares most of its items with a known override but isn't an
+    exact match, it's very likely the SAME pool having drifted rather than
+    a coincidentally-similar unrelated one.
+    """
+    for override_items, label in _BLUEPRINT_POOL_LABEL_OVERRIDES.items():
+        if fp_items == override_items:
+            continue  # exact match -- handled by the normal override path
+        overlap = fp_items & override_items
+        if not overlap:
+            continue
+        smaller = min(len(fp_items), len(override_items))
+        if smaller and len(overlap) / smaller >= _OVERRIDE_DRIFT_OVERLAP_THRESHOLD:
+            logger.warning(
+                f"Blueprint pool {sorted(fp_items)} closely resembles the "
+                f"'{label}' override ({sorted(override_items)}) but isn't an "
+                f"exact match -- CIG may have changed this pool's items; "
+                f"check whether _BLUEPRINT_POOL_LABEL_OVERRIDES needs updating."
+            )
 
 
 def _build_blueprint_body_parts(unique_fps: dict) -> list[str]:
@@ -3209,6 +3245,7 @@ def _build_blueprint_body_parts(unique_fps: dict) -> list[str]:
         override = _BLUEPRINT_POOL_LABEL_OVERRIDES.get(frozenset(items))
         if override is not None:
             return [f"<EM4>[{override}]</EM4>\\n" + "\\n".join(f"- {name}" for name in items)]
+        _warn_if_near_override_miss(frozenset(items))
         only_labels = sorted({l for _, l in only_keys if l})
         if only_labels:
             only_systems = sorted({s for s, _ in only_keys})
@@ -3222,6 +3259,7 @@ def _build_blueprint_body_parts(unique_fps: dict) -> list[str]:
         if override is not None:
             header_entries.append((override, fp, keys))
             continue
+        _warn_if_near_override_miss(frozenset(fp))
         systems = sorted({s for s, _ in keys})
         labels = sorted({l for _, l in keys if l})
         sys_str = ", ".join(systems)

--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -3151,6 +3151,17 @@ def _merge_blueprint_pool(
 # plumbing is needed -- just what's already visible in the rendered list.
 # Add entries here as more ambiguous multi-pool missions are found; any
 # pool not listed keeps the automatic "first item" naming below.
+#
+# ENGLISH ONLY, by construction, in both directions: the keys are English
+# display names, and the values are English labels a maintainer wrote. A
+# non-English run resolves item names from its own loc data, so the lookup
+# cannot match -- and even if it did, it would inject English text into a
+# translated mission body. _pool_label_override therefore skips the table
+# entirely on a non-English run and logs that it did, rather than silently
+# missing on every pool. Localizing the labels is separate, larger work;
+# keying on pool UUIDs would make the lookup language-invariant but costs
+# the "just paste what you see in the list" property that makes this table
+# maintainable, and would not fix the labels themselves.
 _BLUEPRINT_POOL_LABEL_OVERRIDES: dict[frozenset[str], str] = {
     frozenset({
         "P8-AR Rifle", "P8-AR Rifle Magazine (15 Cap)",
@@ -3172,6 +3183,39 @@ _BLUEPRINT_POOL_LABEL_OVERRIDES: dict[frozenset[str], str] = {
 # share a couple of item names (e.g. a common battery/magazine) don't trigger
 # a false-positive warning on every generation run.
 _OVERRIDE_DRIFT_OVERLAP_THRESHOLD = 0.7
+
+
+def _pool_label_override(items, allow_overrides: bool) -> "str | None":
+    """The manual label for this pool's exact item set, or None.
+
+    Single entry point for both call sites below so the override lookup and
+    its drift tripwire can't drift apart, and so the language gate is applied
+    in one place rather than remembered twice.
+
+    *allow_overrides* is False on a non-English run. The table is keyed on
+    English item display names, and a non-English run resolves those names
+    from its own language's loc data, so the lookup can never match: a German
+    user silently got the auto "first item" naming instead of "Yormandi Eyes"
+    with nothing to indicate the table had been consulted at all. The
+    tripwire couldn't report it either, since fully translated names share
+    zero items with the English set and so never reach the overlap
+    threshold -- the one signal designed to catch a stale table stays quiet
+    for exactly the case where it never had a chance. Skipping outright, and
+    saying so once in the log, is honest where a silent miss was not.
+
+    Note this is a real limitation, not a workaround: the labels themselves
+    ("Yormandi Eyes") are maintainer-authored English strings, so matching on
+    another language would still emit English text into a translated mission
+    body. Making these labels properly localizable is a separate piece of
+    work from making the lookup stop failing silently.
+    """
+    if not allow_overrides:
+        return None
+    key = frozenset(items)
+    override = _BLUEPRINT_POOL_LABEL_OVERRIDES.get(key)
+    if override is None:
+        _warn_if_near_override_miss(key)
+    return override
 
 
 def _warn_if_near_override_miss(fp_items: frozenset[str]) -> None:
@@ -3204,7 +3248,8 @@ def _warn_if_near_override_miss(fp_items: frozenset[str]) -> None:
             )
 
 
-def _build_blueprint_body_parts(unique_fps: dict) -> list[str]:
+def _build_blueprint_body_parts(unique_fps: dict,
+                                allow_overrides: bool = True) -> list[str]:
     """Render a mission's blueprint-pool fingerprints into POTENTIAL
     BLUEPRINTS body text blocks, one per distinct item set.
 
@@ -3242,10 +3287,9 @@ def _build_blueprint_body_parts(unique_fps: dict) -> list[str]:
     if len(unique_fps) == 1:
         items = list(next(iter(unique_fps)))
         only_keys = next(iter(unique_fps.values()))
-        override = _BLUEPRINT_POOL_LABEL_OVERRIDES.get(frozenset(items))
+        override = _pool_label_override(items, allow_overrides)
         if override is not None:
             return [f"<EM4>[{override}]</EM4>\\n" + "\\n".join(f"- {name}" for name in items)]
-        _warn_if_near_override_miss(frozenset(items))
         only_labels = sorted({l for _, l in only_keys if l})
         if only_labels:
             only_systems = sorted({s for s, _ in only_keys})
@@ -3255,11 +3299,10 @@ def _build_blueprint_body_parts(unique_fps: dict) -> list[str]:
 
     header_entries = []
     for fp, keys in unique_fps.items():
-        override = _BLUEPRINT_POOL_LABEL_OVERRIDES.get(frozenset(fp))
+        override = _pool_label_override(fp, allow_overrides)
         if override is not None:
             header_entries.append((override, fp, keys))
             continue
-        _warn_if_near_override_miss(frozenset(fp))
         systems = sorted({s for s, _ in keys})
         labels = sorted({l for _, l in keys if l})
         sys_str = ", ".join(systems)
@@ -6541,6 +6584,19 @@ def _run_gen_missions(ctx: dict) -> dict[str, str]:
     records           = ctx["records"]
     forge_dir         = ctx["forge_dir"]
     loc               = ctx["loc"]
+    # Whether this run resolves item names in English. main() sets tag_loc to
+    # the English loc dict, which IS `loc` on an English run and a separately
+    # parsed English base.ini otherwise, so identity here is the language
+    # signal without threading a new ctx key. Gates the manual pool-label
+    # overrides, which are keyed on English display names and so can never
+    # match a translated run -- see _pool_label_override.
+    _overrides_ok     = ctx.get("tag_loc") is loc
+    if not _overrides_ok:
+        logger.info(
+            "Blueprint pool label overrides skipped: this run resolves item "
+            "names in a non-English language, and the override table is keyed "
+            "on English display names. Pools fall back to automatic naming."
+        )
     entity_names      = ctx["entity_names"]
     entity_names_by_filename = ctx.get("entity_names_by_filename", {})
     entity_name_tags  = ctx.get("entity_name_tags", {})
@@ -7012,7 +7068,7 @@ def _run_gen_missions(ctx: dict) -> dict[str, str]:
                     for pool_label, items in by_pool.values():
                         fp = tuple(items)
                         unique_fps.setdefault(fp, []).append((sys_name, pool_label))
-                bp_body_parts = _build_blueprint_body_parts(unique_fps)
+                bp_body_parts = _build_blueprint_body_parts(unique_fps, _overrides_ok)
                 # Join regional sub-sections with a blank line between them
                 # (two `\n` literals = one empty line in CIG's renderer) so
                 # the eye can tell adjacent [Pyro RegionA] / [Pyro RegionB]

--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -3103,16 +3103,160 @@ def _pool_rank_label(pool_name: str) -> str:
 
 def _merge_blueprint_pool(
     mission_blueprints: dict, title_key: str, system_name: str,
-    pool_uuid: str, pool_items: list, pool_label: str,
+    pool_key, pool_items: list, pool_label: str,
 ) -> None:
-    """Merge *pool_items* into mission_blueprints[title_key][system_name][pool_label],
-    preserving order and de-duplicating across repeated calls."""
+    """Merge *pool_items* into
+    mission_blueprints[title_key][system_name][pool_key] = (pool_label, items),
+    preserving order and de-duplicating across repeated calls for the same
+    pool_key.
+
+    *pool_key* is a hashable identity for whichever pool UUID(s) fed this
+    call — a single UUID, or (from scan_contract_generators) a sorted tuple
+    of every pool UUID one contract combined under the same pool_label.
+    Keyed by pool identity, not pool_label alone (#360): two distinct
+    blueprint pools for the same mission title/system (e.g. two different
+    contract variants' randomized reward sets, neither rank-tiered) share
+    the same empty pool_label, and merging on the label alone flattened
+    both variants' items into one list with no way to tell which items
+    came from which pool — reported as a mission's POTENTIAL BLUEPRINTS
+    section showing unrelated item sets (armor + an unrelated weapon) as
+    one undifferentiated block. Keying by pool identity keeps genuinely
+    distinct pools apart while still merging pools a single contract
+    always awards together (see the caller's per-contract grouping); the
+    renderer's fingerprint-based grouping (see the POTENTIAL BLUEPRINTS
+    section builder) then gives each distinct item set its own
+    sub-heading, the same way it already does for rank tiers.
+    """
     per_system = mission_blueprints.setdefault(title_key, {})
-    per_label = per_system.setdefault(system_name, {})
-    existing_items = per_label.setdefault(pool_label, [])
+    per_pool = per_system.setdefault(system_name, {})
+    _label, existing_items = per_pool.setdefault(pool_key, (pool_label, []))
     for item in pool_items:
         if item not in existing_items:
             existing_items.append(item)
+
+
+# Manual label overrides for known multi-pool missions where CIG reuses the
+# SAME description text across every variant (#360 follow-up), so there's
+# no data-driven way to tell which pool belongs to which specific mission
+# instance -- confirmed via a live report cross-referenced against SCMDB
+# (a third-party mission database) for the "Additional Resources For
+# Research" family: every variant (Irradiated Valakkar Pearl delivery,
+# Yormandi Eye delivery, ...) shows the identical description key, so ALL
+# their pools always render together no matter which one a player is
+# actually looking at. Rather than pretend Smart Citizen can tell them
+# apart, every instance shows every known pool, each labeled with what it's
+# FOR -- a player who's seen this once can recognize "this is the Yormandi
+# Eye set" regardless of which specific mission body it's rendering under.
+# Keyed by the pool's own exact item set (order-independent) so no XML/UUID
+# plumbing is needed -- just what's already visible in the rendered list.
+# Add entries here as more ambiguous multi-pool missions are found; any
+# pool not listed keeps the automatic "first item" naming below.
+_BLUEPRINT_POOL_LABEL_OVERRIDES: dict[frozenset, str] = {
+    frozenset({
+        "P8-AR Rifle", "P8-AR Rifle Magazine (15 Cap)",
+        "Palatino Arms", "Palatino Arms Moonfall",
+        "Palatino Core", "Palatino Core Moonfall",
+        "Palatino Helmet", "Palatino Helmet Moonfall",
+        "Palatino Legs", "Palatino Legs Moonfall",
+    }): "Yormandi Eye's",
+    frozenset({
+        'Prism "Bonedust" Laser Shotgun', 'Prism "Deep Sea" Laser Shotgun',
+        'Prism "Firesteel" Laser Shotgun', "Prism Laser Shotgun",
+        "Prism Laser Shotgun Battery (20 cap)", "Siebe Helmet",
+        "Stirling Exploration Suit",
+    }): "Irradiated Valakkar Pearl's",
+}
+
+
+def _build_blueprint_body_parts(unique_fps: dict) -> list[str]:
+    """Render a mission's blueprint-pool fingerprints into POTENTIAL
+    BLUEPRINTS body text blocks, one per distinct item set.
+
+    *unique_fps* maps a fingerprint (tuple of item names) to the list of
+    (system_name, pool_label) keys that produced it -- built by the caller
+    from mission_blueprints[title_key], after narrowing to the systems the
+    specific description body being rendered actually covers.
+
+    A single fingerprint renders as a bare bullet list (no header) unless
+    it carries a rank label or a manual override (see
+    ``_BLUEPRINT_POOL_LABEL_OVERRIDES``), matching the pre-#360 shape for
+    ordinary single-pool missions. Multiple fingerprints each get a
+    ``<EM4>[System, Label]</EM4>`` header -- and when two fingerprints would
+    otherwise produce the IDENTICAL header text (same system, both
+    unlabeled -- e.g. two contract variants of the same research mission
+    with different, non-rank-tiered reward pools, see #360), the header is
+    disambiguated with the fingerprint's OWN first item name (e.g.
+    ``[Rayari_ResourceGathering, P8-AR Rifle Set]`` vs
+    ``[Rayari_ResourceGathering, Prism Laser Shotgun Set]``) rather than an
+    opaque positional counter -- a player scanning just the headers can then
+    tell which section is which without reading every bullet first. Live
+    report: a Rayari research mission's blueprint list originally showed
+    ``[Rayari_ResourceGathering]`` twice with nothing distinguishing which
+    items belonged to which; a follow-up report noted that numbering them
+    "Reward Set 1" / "Reward Set 2" fixed the duplicate-header confusion
+    but still didn't tell a player what each set actually contained -- and
+    that the item-based naming above still didn't, since the two sets are
+    really "which mission variant awards this" rather than "what's in the
+    box." A manual override table lets a maintainer say that directly for
+    missions where it's been worked out. On the rare chance two colliding
+    (non-overridden) sets also share the same first item, a numeric suffix
+    is appended as a last-resort tiebreaker so headers are always at least
+    visually distinct.
+    """
+    if len(unique_fps) == 1:
+        items = list(next(iter(unique_fps)))
+        only_keys = next(iter(unique_fps.values()))
+        override = _BLUEPRINT_POOL_LABEL_OVERRIDES.get(frozenset(items))
+        if override is not None:
+            return [f"<EM4>[{override}]</EM4>\\n" + "\\n".join(f"- {name}" for name in items)]
+        only_labels = sorted({l for _, l in only_keys if l})
+        if only_labels:
+            only_systems = sorted({s for s, _ in only_keys})
+            header = f"{', '.join(only_systems)}, {', '.join(only_labels)}"
+            return [f"<EM4>[{header}]</EM4>\\n" + "\\n".join(f"- {name}" for name in items)]
+        return ["\\n".join(f"- {name}" for name in items)]
+
+    header_entries = []
+    for fp, keys in sorted(unique_fps.items(), key=lambda kv: sorted(kv[1])):
+        override = _BLUEPRINT_POOL_LABEL_OVERRIDES.get(frozenset(fp))
+        if override is not None:
+            header_entries.append((override, fp))
+            continue
+        systems = sorted({s for s, _ in keys})
+        labels = sorted({l for _, l in keys if l})
+        sys_str = ", ".join(systems)
+        header = f"{sys_str}, {', '.join(labels)}" if labels else sys_str
+        header_entries.append((header, fp))
+    header_counts: dict[str, int] = {}
+    for header, _fp in header_entries:
+        header_counts[header] = header_counts.get(header, 0) + 1
+
+    # Pass 1: disambiguate colliding headers by naming each after its own
+    # first item, instead of a meaningless positional counter. Overridden
+    # headers are (in practice) unique already, so they naturally skip this.
+    named_entries = []
+    for header, fp in header_entries:
+        if header_counts[header] > 1:
+            representative = fp[0] if fp else "Unknown"
+            header = f"{header}, {representative} Set"
+        named_entries.append((header, fp))
+
+    # Pass 2: safety net for the rare case where two colliding sets happen
+    # to share the same first item too -- the item-based naming above
+    # would otherwise collide right back into the exact problem it fixes.
+    named_counts: dict[str, int] = {}
+    for header, _fp in named_entries:
+        named_counts[header] = named_counts.get(header, 0) + 1
+    seen_counts: dict[str, int] = {}
+    body_parts: list[str] = []
+    for header, fp in named_entries:
+        if named_counts[header] > 1:
+            seen_counts[header] = seen_counts.get(header, 0) + 1
+            header = f"{header} ({seen_counts[header]})"
+        body_parts.append(
+            f"<EM4>[{header}]</EM4>\\n" + "\\n".join(f"- {name}" for name in fp)
+        )
+    return body_parts
 
 
 # Fuel nozzles hit the filename-fallback tier (#281): their entityClass UUID
@@ -3717,14 +3861,25 @@ def scan_contract_generators(
 
     Returns tuple of:
         - missions: dict mapping title_key → [ContractVariant, ...]
-        - mission_blueprints: dict title_key → dict system_name → dict pool_label → list of craftable item display names.
-          The pool_label dimension preserves rank-tier sub-grouping derived from the
-          pool filename (e.g. ``Rank 0–1`` / ``Rank 2–3`` / ``Rank 4`` from Shubin
-          progression pools). Empty string label is used for pools whose names don't
-          encode a rank — those render with the original system-only header.
-          Multiple system entries indicate per-region pools (e.g. Stanton vs Pyro
-          Shubin HandMining); multiple label entries within a system indicate
-          rank-tiered pools the same contract pulls from at different ranks.
+        - mission_blueprints: dict title_key → dict system_name → dict pool_key →
+          (pool_label, list of craftable item display names). pool_key is a
+          single pool UUID, or a sorted tuple of UUIDs when one contract
+          combines several pools under the same label (see the per-contract
+          grouping below) — never plain pool_label: two distinct pools (e.g.
+          two different contract variants' randomized reward sets for the
+          same mission title) can easily share the same — usually empty,
+          non-rank — label, and keying on the label alone silently merged
+          their item lists into one undifferentiated block with no way to
+          recover which items came from which pool (#360). pool_label still
+          rides along per entry for the renderer's sub-heading, and preserves
+          rank-tier sub-grouping derived from the pool filename (e.g.
+          ``Rank 0–1`` / ``Rank 2–3`` / ``Rank 4`` from Shubin progression
+          pools) — empty string
+          for pools whose names don't encode a rank. Multiple system entries
+          indicate per-region pools (e.g. Stanton vs Pyro Shubin HandMining);
+          multiple pool entries within a system indicate either rank-tiered pools
+          the same contract pulls from at different ranks, or genuinely distinct
+          reward pools sharing the same title/system.
         - mission_items: dict mapping title_key → list of reward item display names
     Sorted by system name for consistent output.
     """
@@ -3738,13 +3893,18 @@ def scan_contract_generators(
     standings_lookup = standings_lookup or {}
     standing_track_lookup = standing_track_lookup or {}
     missions: dict[str, list[ContractVariant]] = {}
-    # Per-system, per-pool-label item lists. The extra label dimension keeps
-    # items from different rank-tier pools separate inside one system so the
-    # renderer can show ``[Stanton, Rank 0–1]`` / ``[Stanton, Rank 2–3]`` /
+    # Per-system, per-pool-identity (label, item list) entries. Keyed by pool
+    # identity (a single pool UUID, or a sorted tuple of UUIDs one contract
+    # combines under the same label) rather than pool_label alone, so
+    # distinct pools stay distinct even when their label is the same empty
+    # non-rank string (#360) — the renderer still groups by label for
+    # display, e.g. ``[Stanton, Rank 0–1]`` / ``[Stanton, Rank 2–3]`` /
     # ``[Stanton, Rank 4]`` instead of one merged blob. Pools whose names
-    # don't carry a rank token use an empty-string label and render with
-    # the original system-only header.
-    mission_blueprints: dict[str, dict[str, dict[str, list[str]]]] = {}
+    # don't carry a rank token use an empty-string label and render with the
+    # original system-only header, unless the renderer finds more than one
+    # distinct item set under that header, in which case it falls back to a
+    # per-pool sub-heading.
+    mission_blueprints: dict[str, dict[str, dict]] = {}
     mission_bp_chance: dict[str, float] = {}
     mission_items: dict[str, list[str]] = {}
 
@@ -3927,6 +4087,27 @@ def scan_contract_generators(
                             contract_has_bp = False
                             contract_bp_chance = 0.0
                             contract_bp_variant = contract.get("debugName", "")
+                            # Accumulate this contract's own BlueprintRewards
+                            # locally, grouped by pool_label, before merging
+                            # into mission_blueprints (#360). This preserves
+                            # two existing behaviors: pools sharing a label
+                            # within ONE contract still combine into one list
+                            # (Adagio: an FPS-gear pool and a ship-component
+                            # pool always awarded together by the same
+                            # contract), while pools with different labels
+                            # stay separate (Shubin rank tiers). The key
+                            # passed to _merge_blueprint_pool is THIS
+                            # contract's own set of pool UUIDs for that
+                            # label, so a DIFFERENT contract variant that
+                            # happens to share (title, system, label) with
+                            # this one -- e.g. two alternate reward pools of
+                            # the same-titled mission -- lands under its own
+                            # key instead of being silently flattened into
+                            # this contract's list. Re-encountering the
+                            # identical pool set (same contract re-parsed, or
+                            # a genuinely repeated variant) still produces
+                            # the same key and dedupes as before.
+                            contract_pools_by_label: dict[str, tuple[list[str], list[str]]] = {}
                             for bp_elem in contract.iter("BlueprintRewards"):
                                 pool_uuid = bp_elem.get("blueprintPool", "")
                                 null_uuid = "00000000-0000-0000-0000-000000000000"
@@ -3941,16 +4122,22 @@ def scan_contract_generators(
                                     # which keeps their sub-section header at the
                                     # bare ``[system_name]`` shape.
                                     pool_label = _pool_rank_label(pool_names.get(pool_uuid, ""))
-                                    _merge_blueprint_pool(
-                                        mission_blueprints, title_key, system_name,
-                                        pool_uuid, pool_items, pool_label,
-                                    )
+                                    label_uuids, label_items = contract_pools_by_label.setdefault(pool_label, ([], []))
+                                    label_uuids.append(pool_uuid)
+                                    for item in pool_items:
+                                        if item not in label_items:
+                                            label_items.append(item)
                                     try:
                                         contract_bp_chance = float(bp_elem.get("chance", "1"))
                                     except (ValueError, TypeError):
                                         contract_bp_chance = 1.0
                                     if title_key not in mission_bp_chance:
                                         mission_bp_chance[title_key] = contract_bp_chance
+                            for pool_label, (label_uuids, label_items) in contract_pools_by_label.items():
+                                _merge_blueprint_pool(
+                                    mission_blueprints, title_key, system_name,
+                                    tuple(sorted(label_uuids)), label_items, pool_label,
+                                )
 
                             # Extract item rewards
                             null_uuid = "00000000-0000-0000-0000-000000000000"
@@ -4061,14 +4248,16 @@ def scan_contract_generators(
                                     missions[sub_title] = []
                                 missions[sub_title].append(ContractVariant(system_name, success_xp, failure_xp, sub_desc or desc_key, contract_flags, spawns, contract_difficulty, contract_has_bp, contract_bp_chance, contract_bp_variant, rank_name, rep_track))
                                 if contract_has_bp and sub_title != title_key:
-                                    for bp_elem in contract.iter("BlueprintRewards"):
-                                        sub_pool_uuid = bp_elem.get("blueprintPool", "")
-                                        if sub_pool_uuid not in blueprint_pools:
-                                            continue
-                                        pool_label = _pool_rank_label(pool_names.get(sub_pool_uuid, ""))
+                                    # Reuse contract_pools_by_label (already
+                                    # scanned above) instead of re-iterating
+                                    # contract.iter("BlueprintRewards") -- a
+                                    # sub-contract inherits the SAME parent
+                                    # contract's pools, so this is the same
+                                    # data, not a fresh scan.
+                                    for pool_label, (label_uuids, label_items) in contract_pools_by_label.items():
                                         _merge_blueprint_pool(
                                             mission_blueprints, sub_title, system_name,
-                                            sub_pool_uuid, blueprint_pools[sub_pool_uuid], pool_label,
+                                            tuple(sorted(label_uuids)), label_items, pool_label,
                                         )
                                     if sub_title not in mission_bp_chance:
                                         mission_bp_chance[sub_title] = contract_bp_chance
@@ -6751,42 +6940,24 @@ def _run_gen_missions(ctx: dict) -> dict[str, str]:
 
                 pools_by_system = mission_blueprints.get(title_key, {})
                 desc_systems = {v.system_name for v in desc_variants if v.has_bp}
-                desc_pools = {s: by_label for s, by_label in pools_by_system.items() if s in desc_systems}
+                desc_pools = {s: by_pool for s, by_pool in pools_by_system.items() if s in desc_systems}
                 if not desc_pools:
                     desc_pools = pools_by_system
-                # Flatten the per-system, per-rank-label structure into one
-                # row per (system, label) pair so equal-item-list pairs can
-                # dedupe under one header (e.g. Stanton + Pyro both award the
-                # same Rank0to1 pool → one "[Stanton, Pyro, Rank 0–1]" header
+                # Flatten the per-system, per-pool structure into one row per
+                # (system, label) pair so equal-item-list pairs can dedupe
+                # under one header (e.g. Stanton + Pyro both award the same
+                # Rank0to1 pool → one "[Stanton, Pyro, Rank 0–1]" header
                 # instead of two). The de-dup key is the item-list tuple as
                 # before; only the header construction grows a label axis.
+                # by_pool is keyed by pool_uuid (see _merge_blueprint_pool,
+                # #360) so distinct pools sharing the same label still land
+                # as separate fingerprints here instead of one merged blob.
                 unique_fps: dict = {}
-                for sys_name, by_label in desc_pools.items():
-                    for pool_label, items in by_label.items():
+                for sys_name, by_pool in desc_pools.items():
+                    for pool_label, items in by_pool.values():
                         fp = tuple(items)
                         unique_fps.setdefault(fp, []).append((sys_name, pool_label))
-                bp_body_parts: list[str] = []
-                if len(unique_fps) == 1:
-                    items = list(next(iter(unique_fps)))
-                    only_keys = next(iter(unique_fps.values()))
-                    only_labels = sorted({l for _, l in only_keys if l})
-                    if only_labels:
-                        only_systems = sorted({s for s, _ in only_keys})
-                        header = f"{', '.join(only_systems)}, {', '.join(only_labels)}"
-                        bp_body_parts.append(
-                            f"<EM4>[{header}]</EM4>\\n" + "\\n".join(f"- {name}" for name in items)
-                        )
-                    else:
-                        bp_body_parts.append("\\n".join(f"- {name}" for name in items))
-                else:
-                    for fp, keys in sorted(unique_fps.items(), key=lambda kv: sorted(kv[1])):
-                        systems = sorted({s for s, _ in keys})
-                        labels = sorted({l for _, l in keys if l})
-                        sys_str = ", ".join(systems)
-                        header = f"{sys_str}, {', '.join(labels)}" if labels else sys_str
-                        bp_body_parts.append(
-                            f"<EM4>[{header}]</EM4>\\n" + "\\n".join(f"- {name}" for name in fp)
-                        )
+                bp_body_parts = _build_blueprint_body_parts(unique_fps)
                 # Join regional sub-sections with a blank line between them
                 # (two `\n` literals = one empty line in CIG's renderer) so
                 # the eye can tell adjacent [Pyro RegionA] / [Pyro RegionB]

--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -3158,13 +3158,13 @@ _BLUEPRINT_POOL_LABEL_OVERRIDES: dict[frozenset, str] = {
         "Palatino Core", "Palatino Core Moonfall",
         "Palatino Helmet", "Palatino Helmet Moonfall",
         "Palatino Legs", "Palatino Legs Moonfall",
-    }): "Yormandi Eye's",
+    }): "Yormandi Eyes",
     frozenset({
         'Prism "Bonedust" Laser Shotgun', 'Prism "Deep Sea" Laser Shotgun',
         'Prism "Firesteel" Laser Shotgun', "Prism Laser Shotgun",
         "Prism Laser Shotgun Battery (20 cap)", "Siebe Helmet",
         "Stirling Exploration Suit",
-    }): "Irradiated Valakkar Pearl's",
+    }): "Irradiated Valakkar Pearls",
 }
 
 
@@ -3217,16 +3217,33 @@ def _build_blueprint_body_parts(unique_fps: dict) -> list[str]:
         return ["\\n".join(f"- {name}" for name in items)]
 
     header_entries = []
-    for fp, keys in sorted(unique_fps.items(), key=lambda kv: sorted(kv[1])):
+    for fp, keys in unique_fps.items():
         override = _BLUEPRINT_POOL_LABEL_OVERRIDES.get(frozenset(fp))
         if override is not None:
-            header_entries.append((override, fp))
+            header_entries.append((override, fp, keys))
             continue
         systems = sorted({s for s, _ in keys})
         labels = sorted({l for _, l in keys if l})
         sys_str = ", ".join(systems)
         header = f"{sys_str}, {', '.join(labels)}" if labels else sys_str
-        header_entries.append((header, fp))
+        header_entries.append((header, fp, keys))
+    # Sort by (system/label keys, header text, fingerprint): the keys
+    # dimension groups naturally-distinct sections (different system or
+    # rank label) in a stable order as before; the header-text tiebreak
+    # resolves ties where the header ALREADY differs -- e.g. two
+    # override-labeled pools sharing the same (system, label) because CIG
+    # reuses one description across every variant, see #360 -- by the
+    # label a maintainer actually gave the pool; and the fingerprint
+    # tiebreak (each pool's own item tuple, content-based and so already
+    # deterministic) covers the remaining case where the header ALSO ties
+    # (e.g. two same-system unlabeled pools before Pass 1 below has told
+    # them apart). Previously this whole ordering fell back to
+    # filesystem/dict-insertion order once system+label tied, which could
+    # vary e.g. the [Yormandi Eyes] vs [Irradiated Valakkar Pearls]
+    # section order across regenerations depending on which contract XML
+    # the scanner happened to reach first.
+    header_entries.sort(key=lambda entry: (sorted(entry[2]), entry[0], entry[1]))
+    header_entries = [(header, fp) for header, fp, _keys in header_entries]
     header_counts: dict[str, int] = {}
     for header, _fp in header_entries:
         header_counts[header] = header_counts.get(header, 0) + 1

--- a/tests/test_blueprint_pools.py
+++ b/tests/test_blueprint_pools.py
@@ -25,6 +25,7 @@ Covers two changes shipped in 1.4.0:
 from __future__ import annotations
 
 import importlib.util
+import logging
 import sys
 from pathlib import Path
 
@@ -522,6 +523,59 @@ class TestBlueprintBodyPartsRendering:
         }
         parts = gen_module._build_blueprint_body_parts(unique_fps)
         assert parts == ["- Totally Unrelated Item"]
+
+    @pytest.mark.regression
+    def test_near_miss_pool_logs_drift_warning(self, gen_module, caplog):
+        """A pool missing just one item from a known override (e.g. CIG
+        dropped "Palatino Legs Moonfall" from the Yormandi Eyes set in a
+        patch) no longer matches exactly and silently reverts to
+        auto-generated naming -- but it should log a warning so a
+        maintainer notices the override table needs updating, instead of
+        the drift going unnoticed forever."""
+        drifted_items = (
+            "P8-AR Rifle", "P8-AR Rifle Magazine (15 Cap)",
+            "Palatino Arms", "Palatino Arms Moonfall",
+            "Palatino Core", "Palatino Core Moonfall",
+            "Palatino Helmet", "Palatino Helmet Moonfall",
+            "Palatino Legs",
+            # "Palatino Legs Moonfall" missing -- simulates CIG drift.
+        )
+        unique_fps = {drifted_items: [("Stanton", "")]}
+        with caplog.at_level(logging.WARNING, logger="generate_enhancements_ini_blueprint_test"):
+            parts = gen_module._build_blueprint_body_parts(unique_fps)
+        # Falls back to the ordinary bare-list rendering (no override match).
+        assert parts == ["- " + "\\n- ".join(drifted_items)]
+        assert any("Yormandi Eyes" in r.message for r in caplog.records), (
+            f"expected a drift warning mentioning the near-matched override, got: "
+            f"{[r.message for r in caplog.records]}"
+        )
+
+    def test_exact_match_does_not_log_drift_warning(self, gen_module, caplog):
+        """An exact override match takes the normal override path and must
+        not ALSO trigger the drift warning against itself."""
+        unique_fps = {
+            (
+                "P8-AR Rifle", "P8-AR Rifle Magazine (15 Cap)",
+                "Palatino Arms", "Palatino Arms Moonfall",
+                "Palatino Core", "Palatino Core Moonfall",
+                "Palatino Helmet", "Palatino Helmet Moonfall",
+                "Palatino Legs", "Palatino Legs Moonfall",
+            ): [("Stanton", "")],
+        }
+        with caplog.at_level(logging.WARNING, logger="generate_enhancements_ini_blueprint_test"):
+            gen_module._build_blueprint_body_parts(unique_fps)
+        assert caplog.records == []
+
+    def test_unrelated_pool_does_not_log_drift_warning(self, gen_module, caplog):
+        """A pool with low/no item overlap with any override must not warn
+        -- the threshold exists specifically to avoid noise on genuinely
+        unrelated pools."""
+        unique_fps = {
+            ("Totally Unrelated Item", "Another Unrelated Item"): [("Stanton", "")],
+        }
+        with caplog.at_level(logging.WARNING, logger="generate_enhancements_ini_blueprint_test"):
+            gen_module._build_blueprint_body_parts(unique_fps)
+        assert caplog.records == []
 
 
 class TestBlueprintNameTags:

--- a/tests/test_blueprint_pools.py
+++ b/tests/test_blueprint_pools.py
@@ -106,12 +106,15 @@ class TestMultiSourcePoolMerge:
         per_system = mission_blueprints["adagio_mining_title"]
         assert "Stanton" in per_system, f"expected 'Stanton' system, got {list(per_system)}"
 
-        # mission_blueprints is now {title: {system: {pool_label: [items]}}}.
-        # No rank-tier names supplied here, so the items land under the
-        # empty-label bucket. The bug guarded against was the second pool's
-        # items being silently dropped — gather across all labels to assert
-        # both pools' items survived.
-        items = [it for items_list in per_system["Stanton"].values() for it in items_list]
+        # mission_blueprints is now {title: {system: {pool_key: (label, [items])}}},
+        # pool_key being a UUID or (since both pools here share the same
+        # contract and label) a combined tuple of the contract's pool UUIDs
+        # (#360). No rank-tier names supplied here, so both pools land under
+        # the empty label and — being from the SAME contract — merge into
+        # one entry, same as before the #360 fix. The bug originally guarded
+        # against here was the second pool's items being silently dropped —
+        # gather across all entries to assert both pools' items survived.
+        items = [it for _label, items_list in per_system["Stanton"].values() for it in items_list]
         assert "Pyro Pickaxe" in items
         assert "FPS Mining Helmet" in items
         assert "Norfield Power Plant" in items
@@ -146,9 +149,12 @@ class TestMultiSourcePoolMerge:
             contractgen_dir, reputation_lookup={},
             blueprint_pools=blueprint_pools, entity_names={},
         )
-        # Both pools share the empty-label bucket (no rank info supplied),
-        # so the merge+dedup happens within that bucket as before.
-        items = mission_blueprints["dupe_title"]["Stanton"][""]
+        # Both pools come from the SAME contract and share the empty label,
+        # so they merge into one entry keyed by their combined pool-UUID
+        # tuple (#360) — the merge+dedup happens within that entry as before.
+        per_system = mission_blueprints["dupe_title"]["Stanton"]
+        assert len(per_system) == 1, f"expected one merged entry, got {per_system}"
+        _label, items = next(iter(per_system.values()))
         assert items.count("Shared Item") == 1, (
             f"de-dup failed — 'Shared Item' appears {items.count('Shared Item')}× in {items}"
         )
@@ -176,8 +182,308 @@ class TestMultiSourcePoolMerge:
             blueprint_pools={"pool-only": ["Only Item"]},
             entity_names={},
         )
-        assert mission_blueprints["single_title"]["Stanton"][""] == ["Only Item"]
+        per_system = mission_blueprints["single_title"]["Stanton"]
+        assert len(per_system) == 1, f"expected one entry, got {per_system}"
+        label, items = next(iter(per_system.values()))
+        assert label == ""
+        assert items == ["Only Item"]
         assert mission_bp_chance["single_title"] == pytest.approx(0.5)
+
+
+class TestDistinctContractVariantsStaySeparate:
+    """Regression guard for #360: a Discord user reported a "Yormandi Eye"
+    collection mission's POTENTIAL BLUEPRINTS list showing Prism Shotgun
+    items mixed in with an unrelated Palatino-armor/P8-AR-rifle set, with
+    third-party trackers only ever showing the latter.
+
+    Root cause: CIG can generate the SAME mission title from multiple
+    distinct <Contract> variants (e.g. different randomized reward-pool
+    rolls), each with its own <BlueprintRewards> pool. Pre-fix,
+    ``_merge_blueprint_pool`` keyed only on (title, system, pool_label),
+    and non-rank-tiered pools all share the empty label — so two totally
+    unrelated variants' pools landed in the same bucket and got flattened
+    into one list with no way to tell them apart. The fix keys by the
+    pool's own identity instead, while still merging pools a single
+    contract legitimately awards together (see TestMultiSourcePoolMerge's
+    Adagio case) and still separating rank-tiered pools by label (see
+    TestPoolRankLabels)."""
+
+    @pytest.mark.regression
+    def test_two_contract_variants_same_title_stay_separate(self, gen_module, tmp_path):
+        """Two DIFFERENT <Contract> elements (distinct variants, as CIG's
+        contractgen produces for a randomized mission) sharing one title,
+        each with its own single non-rank-tiered pool, must NOT merge into
+        one list -- unlike TestMultiSourcePoolMerge's Adagio case, these
+        are two separate contracts, not one contract's simultaneous pools."""
+        contractgen_dir = tmp_path / "contractgenerator"
+        contractgen_dir.mkdir()
+        contract_xml = '''
+<ContractGeneratorHandler_List debugName="YormandiEye_Stanton">
+    <Contract debugName="YormandiEye_Stanton_VariantA">
+        <Title>
+            <ContractStringParam param="Title" value="@yormandi_eye_title"/>
+            <ContractStringParam param="Description" value="@yormandi_eye_desc"/>
+        </Title>
+        <BlueprintRewards blueprintPool="pool-palatino-p8ar" chance="1.0"/>
+    </Contract>
+    <Contract debugName="YormandiEye_Stanton_VariantB">
+        <Title>
+            <ContractStringParam param="Title" value="@yormandi_eye_title"/>
+            <ContractStringParam param="Description" value="@yormandi_eye_desc"/>
+        </Title>
+        <BlueprintRewards blueprintPool="pool-prism" chance="1.0"/>
+    </Contract>
+</ContractGeneratorHandler_List>
+'''
+        _write_contractgen_xml(contractgen_dir, "yormandi.xml", contract_xml)
+
+        blueprint_pools = {
+            "pool-palatino-p8ar": ["Palatino Arms", "Palatino Core", "P8-AR Rifle"],
+            "pool-prism": ['Prism "Irradiated" Laser Shotgun', "Prism Laser Shotgun Battery (20 cap)"],
+        }
+
+        _, mission_blueprints, _, _ = gen_module.scan_contract_generators(
+            contractgen_dir, reputation_lookup={},
+            blueprint_pools=blueprint_pools, entity_names={},
+        )
+
+        per_system = mission_blueprints["yormandi_eye_title"]["Stanton"]
+        assert len(per_system) == 2, (
+            f"expected the two variants' pools to stay as separate entries, "
+            f"got {len(per_system)}: {per_system}"
+        )
+        item_sets = [frozenset(items) for _label, items in per_system.values()]
+        assert frozenset(blueprint_pools["pool-palatino-p8ar"]) in item_sets
+        assert frozenset(blueprint_pools["pool-prism"]) in item_sets
+        # The bug's exact symptom: no single entry should contain items
+        # from BOTH pools.
+        for items_set in item_sets:
+            assert not (items_set & frozenset(blueprint_pools["pool-prism"])
+                        and items_set & frozenset(blueprint_pools["pool-palatino-p8ar"])), (
+                f"a Palatino/P8-AR item and a Prism item ended up in the same "
+                f"entry — pools were incorrectly merged: {items_set}"
+            )
+
+    def test_two_contract_variants_identical_pool_still_dedupes(self, gen_module, tmp_path):
+        """Two variants that happen to award the EXACT same pool (e.g. the
+        same reward set spawned under two debugName suffixes) should still
+        collapse into one entry, not double up -- the fix must not turn
+        legitimate re-encounters of the identical pool into duplicates."""
+        contractgen_dir = tmp_path / "contractgenerator"
+        contractgen_dir.mkdir()
+        contract_xml = '''
+<ContractGeneratorHandler_List debugName="SamePool_Stanton">
+    <Contract debugName="SamePool_Stanton_VariantA">
+        <Title>
+            <ContractStringParam param="Title" value="@samepool_title"/>
+            <ContractStringParam param="Description" value="@samepool_desc"/>
+        </Title>
+        <BlueprintRewards blueprintPool="pool-shared" chance="1.0"/>
+    </Contract>
+    <Contract debugName="SamePool_Stanton_VariantB">
+        <Title>
+            <ContractStringParam param="Title" value="@samepool_title"/>
+            <ContractStringParam param="Description" value="@samepool_desc"/>
+        </Title>
+        <BlueprintRewards blueprintPool="pool-shared" chance="1.0"/>
+    </Contract>
+</ContractGeneratorHandler_List>
+'''
+        _write_contractgen_xml(contractgen_dir, "samepool.xml", contract_xml)
+
+        _, mission_blueprints, _, _ = gen_module.scan_contract_generators(
+            contractgen_dir, reputation_lookup={},
+            blueprint_pools={"pool-shared": ["Shared Item A", "Shared Item B"]},
+            entity_names={},
+        )
+        per_system = mission_blueprints["samepool_title"]["Stanton"]
+        assert len(per_system) == 1, (
+            f"identical pool re-encountered across variants should dedupe "
+            f"into one entry, got {len(per_system)}: {per_system}"
+        )
+        _label, items = next(iter(per_system.values()))
+        assert items == ["Shared Item A", "Shared Item B"]
+
+
+class TestBlueprintBodyPartsRendering:
+    """Regression guard for the #360 follow-up: separating distinct pools
+    (TestDistinctContractVariantsStaySeparate above) fixed the merged-list
+    bug, but a live report showed the fix's OWN output looked broken for
+    Rayari research missions -- two sections both rendering the bare
+    ``<EM4>[Rayari_ResourceGathering]</EM4>`` header (same system, neither
+    pool rank-tiered so both labels are empty) sitting over two different
+    item lists, reading as a duplicate/bug rather than two distinct reward
+    sets. ``_build_blueprint_body_parts`` is the extracted, directly
+    testable form of the inline body-part renderer in _run_gen_missions."""
+
+    def test_single_pool_no_header(self, gen_module):
+        """An ordinary single-pool mission still renders as a bare bullet
+        list with no header -- the #360 fix must not add headers where
+        there was never more than one pool to begin with."""
+        unique_fps = {
+            ("Item A", "Item B"): [("Stanton", "")],
+        }
+        parts = gen_module._build_blueprint_body_parts(unique_fps)
+        assert parts == ["- Item A\\n- Item B"]
+
+    def test_single_pool_with_rank_label_still_headers(self, gen_module):
+        """A single rank-tiered pool keeps its header (pre-#360 shape)."""
+        unique_fps = {
+            ("Item A",): [("Stanton", "Rank 0–1")],
+        }
+        parts = gen_module._build_blueprint_body_parts(unique_fps)
+        assert parts == ["<EM4>[Stanton, Rank 0–1]</EM4>\\n- Item A"]
+
+    def test_distinct_rank_labels_get_their_own_untouched_headers(self, gen_module):
+        """Rank-tiered pools already have a distinguishing label, so the
+        collision-numbering must NOT kick in (Shubin case, TestPoolRankLabels)."""
+        unique_fps = {
+            ("Surveyor-Go",): [("Stanton", "Rank 0–1")],
+            ("FullSpec",):    [("Stanton", "Rank 4")],
+        }
+        parts = gen_module._build_blueprint_body_parts(unique_fps)
+        assert parts == [
+            "<EM4>[Stanton, Rank 0–1]</EM4>\\n- Surveyor-Go",
+            "<EM4>[Stanton, Rank 4]</EM4>\\n- FullSpec",
+        ]
+
+    @pytest.mark.regression
+    def test_colliding_headers_named_after_first_item(self, gen_module):
+        """The exact live-reported shape: two unlabeled pools in the same
+        system produce the same base header. A follow-up live report noted
+        that numbering them "Reward Set 1" / "Reward Set 2" fixed the
+        duplicate-header confusion but didn't tell a player what each set
+        actually contained -- so each collision is now named after its own
+        first item instead."""
+        unique_fps = {
+            ("P8-AR Rifle", "Palatino Arms"): [("Rayari_ResourceGathering", "")],
+            ('Prism "Bonedust" Laser Shotgun', "Siebe Helmet"): [("Rayari_ResourceGathering", "")],
+        }
+        parts = gen_module._build_blueprint_body_parts(unique_fps)
+        assert len(parts) == 2
+        headers = [p.split("\\n", 1)[0] for p in parts]
+        assert headers == [
+            "<EM4>[Rayari_ResourceGathering, P8-AR Rifle Set]</EM4>",
+            '<EM4>[Rayari_ResourceGathering, Prism "Bonedust" Laser Shotgun Set]</EM4>',
+        ]
+        assert headers[0] != headers[1], "colliding headers must be distinguishable"
+        # Each item list stays attached to its own header, in order.
+        assert "- P8-AR Rifle" in parts[0] and "- Palatino Arms" in parts[0]
+        assert '- Prism "Bonedust" Laser Shotgun' in parts[1] and "- Siebe Helmet" in parts[1]
+
+    def test_non_colliding_headers_get_no_extra_naming(self, gen_module):
+        """Two pools in DIFFERENT systems produce naturally distinct headers
+        -- no item-based suffix should be added since there's no collision."""
+        unique_fps = {
+            ("Item A",): [("Stanton", "")],
+            ("Item B",): [("Pyro", "")],
+        }
+        parts = gen_module._build_blueprint_body_parts(unique_fps)
+        headers = [p.split("\\n", 1)[0] for p in parts]
+        assert headers == ["<EM4>[Pyro]</EM4>", "<EM4>[Stanton]</EM4>"]
+
+    def test_three_way_collision_all_named(self, gen_module):
+        """Three colliding headers all get named after their first item,
+        not just the first repeat."""
+        unique_fps = {
+            ("A",): [("Stanton", "")],
+            ("B",): [("Stanton", "")],
+            ("C",): [("Stanton", "")],
+        }
+        parts = gen_module._build_blueprint_body_parts(unique_fps)
+        headers = [p.split("\\n", 1)[0] for p in parts]
+        assert headers == [
+            "<EM4>[Stanton, A Set]</EM4>",
+            "<EM4>[Stanton, B Set]</EM4>",
+            "<EM4>[Stanton, C Set]</EM4>",
+        ]
+
+    @pytest.mark.regression
+    def test_double_collision_falls_back_to_numeric_tiebreaker(self, gen_module):
+        """Edge case: two colliding pools that ALSO happen to share the same
+        first item name -- the item-based naming would collide right back
+        into the original bug, so a numeric suffix is the last-resort
+        tiebreaker to guarantee headers are always visually distinct."""
+        unique_fps = {
+            ("Shared Item", "Unique A"): [("Stanton", "")],
+            ("Shared Item", "Unique B"): [("Stanton", "")],
+        }
+        parts = gen_module._build_blueprint_body_parts(unique_fps)
+        headers = [p.split("\\n", 1)[0] for p in parts]
+        assert headers == [
+            "<EM4>[Stanton, Shared Item Set (1)]</EM4>",
+            "<EM4>[Stanton, Shared Item Set (2)]</EM4>",
+        ]
+        assert headers[0] != headers[1]
+
+    @pytest.mark.regression
+    def test_known_rayari_pools_use_manual_override_labels(self, gen_module):
+        """Final iteration on the #360 follow-up: per-mission scoping isn't
+        possible (CIG reuses one description across every "Additional
+        Resources For Research" variant, confirmed via SCMDB), so a manual
+        override table names each known pool after what it's actually for,
+        instead of an auto-derived "first item" label. Every instance of
+        this mission shows both sets regardless -- the point is a player
+        can recognize "this is the Yormandi Eye set" wherever it appears."""
+        unique_fps = {
+            (
+                "P8-AR Rifle", "P8-AR Rifle Magazine (15 Cap)",
+                "Palatino Arms", "Palatino Arms Moonfall",
+                "Palatino Core", "Palatino Core Moonfall",
+                "Palatino Helmet", "Palatino Helmet Moonfall",
+                "Palatino Legs", "Palatino Legs Moonfall",
+            ): [("Rayari_ResourceGathering", "")],
+            (
+                'Prism "Bonedust" Laser Shotgun', 'Prism "Deep Sea" Laser Shotgun',
+                'Prism "Firesteel" Laser Shotgun', "Prism Laser Shotgun",
+                "Prism Laser Shotgun Battery (20 cap)", "Siebe Helmet",
+                "Stirling Exploration Suit",
+            ): [("Rayari_ResourceGathering", "")],
+        }
+        parts = gen_module._build_blueprint_body_parts(unique_fps)
+        headers = [p.split("\\n", 1)[0] for p in parts]
+        assert headers == [
+            "<EM4>[Yormandi Eye's]</EM4>",
+            "<EM4>[Irradiated Valakkar Pearl's]</EM4>",
+        ]
+        # The system-name prefix and item-based naming are fully replaced,
+        # not appended to.
+        assert "Rayari_ResourceGathering" not in "".join(headers)
+        assert "Set" not in "".join(headers)
+
+    def test_override_applies_even_as_the_only_pool(self, gen_module):
+        """The override is keyed by item content, not by "is this
+        colliding with another pool" -- a mission where this exact set is
+        the ONLY pool should still get the override label, not render as a
+        bare unheaded list."""
+        unique_fps = {
+            (
+                "P8-AR Rifle", "P8-AR Rifle Magazine (15 Cap)",
+                "Palatino Arms", "Palatino Arms Moonfall",
+                "Palatino Core", "Palatino Core Moonfall",
+                "Palatino Helmet", "Palatino Helmet Moonfall",
+                "Palatino Legs", "Palatino Legs Moonfall",
+            ): [("Rayari_ResourceGathering", "")],
+        }
+        parts = gen_module._build_blueprint_body_parts(unique_fps)
+        assert parts == [
+            "<EM4>[Yormandi Eye's]</EM4>\\n"
+            "- P8-AR Rifle\\n- P8-AR Rifle Magazine (15 Cap)\\n"
+            "- Palatino Arms\\n- Palatino Arms Moonfall\\n"
+            "- Palatino Core\\n- Palatino Core Moonfall\\n"
+            "- Palatino Helmet\\n- Palatino Helmet Moonfall\\n"
+            "- Palatino Legs\\n- Palatino Legs Moonfall"
+        ]
+
+    def test_unrelated_pools_are_unaffected_by_overrides(self, gen_module):
+        """A pool whose item set doesn't match any override entry keeps the
+        existing automatic naming -- the override table is additive, not a
+        behavior change for everything else."""
+        unique_fps = {
+            ("Totally Unrelated Item",): [("Stanton", "")],
+        }
+        parts = gen_module._build_blueprint_body_parts(unique_fps)
+        assert parts == ["- Totally Unrelated Item"]
 
 
 class TestBlueprintNameTags:
@@ -840,11 +1146,14 @@ class TestPoolRankLabels:
         )
 
         per_system = mission_blueprints["shubin_title"]["Stanton"]
-        # Two distinct rank-label buckets, NOT merged into one.
-        assert "Rank 0–1" in per_system
-        assert "Rank 4" in per_system
-        assert per_system["Rank 0–1"] == ["Surveyor-Go [IND-S0-C]", "Lawson Mining Laser"]
-        assert per_system["Rank 4"] == ["FullSpec [IND-S2-A]", "Arbor MH2 Mining Laser"]
+        # Two distinct rank-label entries, NOT merged into one (each pool's
+        # own label differs, so the per-contract grouping keeps them apart
+        # even though both come from the same contract).
+        by_label = {label: items for label, items in per_system.values()}
+        assert "Rank 0–1" in by_label
+        assert "Rank 4" in by_label
+        assert by_label["Rank 0–1"] == ["Surveyor-Go [IND-S0-C]", "Lawson Mining Laser"]
+        assert by_label["Rank 4"] == ["FullSpec [IND-S2-A]", "Arbor MH2 Mining Laser"]
 
     def test_scan_falls_back_to_empty_label_when_pool_names_missing(self, gen_module, tmp_path):
         """When pool_names isn't supplied (or doesn't cover a pool UUID),
@@ -872,8 +1181,10 @@ class TestPoolRankLabels:
             # pool_names omitted → all pools resolve to empty label
         )
         per_system = mission_blueprints["nolabel_title"]["Stanton"]
-        assert list(per_system.keys()) == [""], f"expected empty-label-only, got {per_system}"
-        assert per_system[""] == ["Item A", "Item B"]
+        assert len(per_system) == 1, f"expected one entry, got {per_system}"
+        label, items = next(iter(per_system.values()))
+        assert label == "", f"expected empty label, got {per_system}"
+        assert items == ["Item A", "Item B"]
 
 
 class TestOrphanPuDescCleanup:

--- a/tests/test_blueprint_pools.py
+++ b/tests/test_blueprint_pools.py
@@ -455,6 +455,47 @@ class TestBlueprintBodyPartsRendering:
         assert "Rayari_ResourceGathering" not in "".join(headers)
         assert "Set" not in "".join(headers)
 
+    def test_overrides_are_skipped_on_a_non_english_run(self, gen_module):
+        """The table is keyed on English display names, so a run resolving
+        names in another language can never match it. It used to be consulted
+        anyway: every lookup missed, the labels silently reverted to automatic
+        naming, and the drift tripwire could not report it either, because
+        fully translated names share zero items with the English set and never
+        reach the overlap threshold. The one signal meant to catch a stale
+        table stayed quiet for exactly the case it never had a chance at.
+
+        Skipping explicitly is what makes that visible in the log instead.
+        """
+        unique_fps = {
+            (
+                "P8-AR Rifle", "P8-AR Rifle Magazine (15 Cap)",
+                "Palatino Arms", "Palatino Arms Moonfall",
+                "Palatino Core", "Palatino Core Moonfall",
+                "Palatino Helmet", "Palatino Helmet Moonfall",
+                "Palatino Legs", "Palatino Legs Moonfall",
+            ): [("Rayari_ResourceGathering", "")],
+        }
+        parts = gen_module._build_blueprint_body_parts(unique_fps, False)
+        assert "Yormandi Eyes" not in "".join(parts)
+        # ...and the items still render, just under automatic naming.
+        assert "P8-AR Rifle" in "".join(parts)
+
+        # Same input on an English run keeps the manual label.
+        parts_en = gen_module._build_blueprint_body_parts(unique_fps, True)
+        assert "Yormandi Eyes" in "".join(parts_en)
+
+    def test_non_english_run_does_not_log_a_drift_warning(self, gen_module, caplog):
+        """A translated pool is not drift, and reporting it as such would
+        train a maintainer to ignore the one warning that matters. The gate
+        has to skip the tripwire too, not just the lookup."""
+        import logging
+        translated = {
+            ("P8-AR Gewehr", "Palatino Arme", "Palatino Kern"): [("Rayari", "")],
+        }
+        with caplog.at_level(logging.WARNING):
+            gen_module._build_blueprint_body_parts(translated, False)
+        assert not [r for r in caplog.records if "override" in r.message.lower()]
+
     @pytest.mark.regression
     def test_override_order_is_independent_of_insertion_order(self, gen_module):
         """Both override pools share the identical (system, label) key

--- a/tests/test_blueprint_pools.py
+++ b/tests/test_blueprint_pools.py
@@ -442,14 +442,52 @@ class TestBlueprintBodyPartsRendering:
         }
         parts = gen_module._build_blueprint_body_parts(unique_fps)
         headers = [p.split("\\n", 1)[0] for p in parts]
+        # Alphabetical by label text ("Irradiated..." < "Yormandi...") --
+        # see test_override_order_is_independent_of_insertion_order below
+        # for why this must not depend on dict/scan order.
         assert headers == [
-            "<EM4>[Yormandi Eye's]</EM4>",
-            "<EM4>[Irradiated Valakkar Pearl's]</EM4>",
+            "<EM4>[Irradiated Valakkar Pearls]</EM4>",
+            "<EM4>[Yormandi Eyes]</EM4>",
         ]
         # The system-name prefix and item-based naming are fully replaced,
         # not appended to.
         assert "Rayari_ResourceGathering" not in "".join(headers)
         assert "Set" not in "".join(headers)
+
+    @pytest.mark.regression
+    def test_override_order_is_independent_of_insertion_order(self, gen_module):
+        """Both override pools share the identical (system, label) key
+        ("Rayari_ResourceGathering", ""), so before this fix their relative
+        order in the rendered body was decided by dict/insertion order --
+        which traces back to whichever contract XML the scanner happened to
+        reach first, making the section order non-deterministic across
+        regenerations. Sorting by header text as the tiebreak fixes that:
+        feeding the pools in the OPPOSITE insertion order must still
+        produce the same output order."""
+        yormandi_fp = (
+            "P8-AR Rifle", "P8-AR Rifle Magazine (15 Cap)",
+            "Palatino Arms", "Palatino Arms Moonfall",
+            "Palatino Core", "Palatino Core Moonfall",
+            "Palatino Helmet", "Palatino Helmet Moonfall",
+            "Palatino Legs", "Palatino Legs Moonfall",
+        )
+        irradiated_fp = (
+            'Prism "Bonedust" Laser Shotgun', 'Prism "Deep Sea" Laser Shotgun',
+            'Prism "Firesteel" Laser Shotgun', "Prism Laser Shotgun",
+            "Prism Laser Shotgun Battery (20 cap)", "Siebe Helmet",
+            "Stirling Exploration Suit",
+        )
+        keys = [("Rayari_ResourceGathering", "")]
+
+        forward = {yormandi_fp: keys, irradiated_fp: keys}
+        reversed_ = {irradiated_fp: keys, yormandi_fp: keys}
+
+        forward_headers = [p.split("\\n", 1)[0] for p in gen_module._build_blueprint_body_parts(forward)]
+        reversed_headers = [p.split("\\n", 1)[0] for p in gen_module._build_blueprint_body_parts(reversed_)]
+        assert forward_headers == reversed_headers == [
+            "<EM4>[Irradiated Valakkar Pearls]</EM4>",
+            "<EM4>[Yormandi Eyes]</EM4>",
+        ]
 
     def test_override_applies_even_as_the_only_pool(self, gen_module):
         """The override is keyed by item content, not by "is this
@@ -467,7 +505,7 @@ class TestBlueprintBodyPartsRendering:
         }
         parts = gen_module._build_blueprint_body_parts(unique_fps)
         assert parts == [
-            "<EM4>[Yormandi Eye's]</EM4>\\n"
+            "<EM4>[Yormandi Eyes]</EM4>\\n"
             "- P8-AR Rifle\\n- P8-AR Rifle Magazine (15 Cap)\\n"
             "- Palatino Arms\\n- Palatino Arms Moonfall\\n"
             "- Palatino Core\\n- Palatino Core Moonfall\\n"

--- a/tests/test_mission_variant_tuple.py
+++ b/tests/test_mission_variant_tuple.py
@@ -147,5 +147,3 @@ class TestRunGenMissionsTupleConsumers:
         assert v[7] is True
         assert v[10] == "Rookie"
         assert v[11] == "Security"
-
-


### PR DESCRIPTION
## Summary
- A Discord user (JakP) reported that Rayari research missions ("Additional Resources For Research") show blueprint items from two unrelated reward sets mixed into one list, with third-party trackers only ever showing one set.
- Root cause: multiple mission variants (one requiring an Irradiated Valakkar Pearl, another a Yormandi Eye) share the same title AND description text, so their separate blueprint reward pools were being flattened together during generation.
- `_merge_blueprint_pool` now keys pools by their own identity instead of by label alone, so genuinely distinct pools stay distinct instead of collapsing into one list when they share an empty (non-rank) label.
- Since CIG reuses the same description across every variant of this mission (confirmed via cross-referencing SCMDB), there's no way to show only the relevant pool per mission instance from data available in the pipeline. Instead, the two known pools are labeled by what they actually reward (`[Yormandi Eyes]` / `[Irradiated Valakkar Pearls]`) via a small hand-curated lookup, so a player can tell them apart regardless of which specific mission instance they're viewing.
- Section order is deterministic: sorted by header text and pool content, not by whichever contract XML happens to get scanned first, so the two sections render in a stable order across regenerations.
- The label overrides match on exact item-set equality. If a future CIG patch changes either pool's items, the override will stop matching — a warning is now logged when a pool closely resembles a known override without matching it exactly, so the table gets flagged for updating instead of silently going stale.

## Test plan
- [x] `pytest -q` — 1591 passed, 21 skipped
- [x] New regression tests covering: distinct pools staying separate, identical pools still deduping, colliding headers getting disambiguated, the manual label override producing the exact requested text, section order staying stable regardless of insertion order, and the drift-warning firing on a near-miss while staying silent on exact matches and unrelated pools
- [x] Built a portable and manually verified the fix against real extracted game data (Rayari research missions now show `[Yormandi Eyes]` and `[Irradiated Valakkar Pearls]` instead of one merged list)

Fixes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)