### PR TITLE
Run the Tag Builder freshness check at startup, not only on channel switch (#363)

### DIFF
--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -506,12 +506,45 @@ class EnhancementsTab(QWidget):
         genuinely lack those tags); leave it grey when they already match. A
         missing stamp (channels generated before this feature, or never
         generated) reads as dirty, so the button stays clickable exactly as it
-        did before until the next generation records a stamp."""
+        did before until the next generation records a stamp.
+
+        #363 made this the single definition of "the generated INIs don't match
+        the tag config", called from every point that can invalidate them
+        (launch, an import, a finished run) rather than only a channel switch,
+        so it also gained the gate below: being stale requires there to be
+        something that *can* be stale. With no enhancement output on disk there
+        is nothing to be out of date, and Generate Enhancements is already
+        lit for the missing files, so lighting this one too would just put a
+        second red button in front of a new user who has done nothing wrong.
+        """
         if getattr(self, "_apply_tag_btn", None) is None:
+            return
+        if not self._enhancements_output_exists():
+            self._set_tag_btn_dirty(False)
             return
         stamp = AppSettings.get_tag_config_stamp()
         current = self._live_tag_config_fingerprint()
         self._set_tag_btn_dirty(not stamp or stamp != current)
+
+    def _enhancements_output_exists(self) -> bool:
+        """True if any enabled category has at least one generated INI on disk.
+
+        Deliberately "any", not "all": a partially generated set is still
+        output that a tag-config change can invalidate, and the missing half is
+        Generate Enhancements' business (_compute_initial_enhancements_dirty
+        lights it for exactly that). Guarded with getattr so it stays a safe
+        no-op if the enhancements group hasn't been built — setup_ui builds it
+        before the Tag Builder group, so in practice it always has.
+        """
+        checkboxes = getattr(self, "_enhancements_checkboxes", None)
+        if not checkboxes:
+            return False
+        cache_dir = AppSettings.get_cache_dir()
+        return any(
+            (cache_dir / fn).exists()
+            for key, cb in checkboxes.items() if cb.isChecked()
+            for fn in self._files_for_category(key)
+        )
 
     def _on_category_checkbox_changed(self):
         """Enable Apply button if any checkbox differs from saved settings."""
@@ -874,7 +907,16 @@ class EnhancementsTab(QWidget):
         self._apply_tag_btn = QPushButton(tr("enhancements.apply_tag_changes_btn"))
         self._apply_tag_btn.clicked.connect(self._apply_tag_builder)
         btn_row.addWidget(self._apply_tag_btn)
-        self._set_tag_btn_dirty(False)
+        # #363: derive the starting state rather than asserting clean. This
+        # was an unconditional _set_tag_btn_dirty(False), which made launch
+        # the one moment the freshness check never ran — it was wired only to
+        # the channel switch — so INIs that didn't match the tag config were
+        # invisible on startup behind two grey buttons. See the module
+        # docstring of tests/test_tag_config_staleness_startup.py for the
+        # reported symptom and why cycling the checkbox appeared to fix it.
+        # Safe here: the pages, the annotate checkbox and _apply_tag_btn are
+        # all built above, so the fingerprint comes from the live pages.
+        self.refresh_tag_builder_dirty_state()
 
         self._reset_tag_btn = QPushButton(tr("enhancements.reset_defaults_btn"))
         self._reset_tag_btn.setToolTip(tr("enhancements.reset_tag_tooltip"))
@@ -1006,8 +1048,14 @@ class EnhancementsTab(QWidget):
             annotate_cb.setChecked(AppSettings.get_tag_annotate_mission_descs())
             annotate_cb.blockSignals(False)
         # apply_config emits config_changed per page, which lights the Save
-        # button — but nothing is actually unsaved here, so clear it.
-        self._set_tag_btn_dirty(False)
+        # button — but nothing is actually *unsaved* here, so drop that
+        # signal. #363: re-derive rather than clearing outright, though. An
+        # import that changes the tag config leaves the generated INIs built
+        # from the pre-import one, and clearing unconditionally hid that the
+        # same way launch did: grey button, stale output, no way to tell.
+        # The pages now equal the persisted config, so this reports only
+        # genuine staleness and never the unsaved edits it's here to drop.
+        self.refresh_tag_builder_dirty_state()
         logger.info("Tag Builder: reloaded configs from settings for %s", ", ".join(pages))
 
     def flush_pending_tag_edits(self) -> None:
@@ -1020,7 +1068,14 @@ class EnhancementsTab(QWidget):
         whatever was last committed via Save Tag Changes.
         """
         self._persist_tag_builder_state()
-        self._set_tag_btn_dirty(False)
+        # #363: persisting is not regenerating. Clearing the button outright
+        # here threw away a correct "you still need to regenerate" signal the
+        # user had already been shown: edit the Tag Builder, click Export
+        # Settings, and the edits landed in settings while the INIs kept the
+        # old config — stale output behind a grey button, the same end state
+        # as the launch and import cases. Re-deriving keeps it lit for exactly
+        # as long as the output really is behind.
+        self.refresh_tag_builder_dirty_state()
 
     def _set_tag_btn_dirty(self, dirty: bool) -> None:
         """Single chokepoint for the button's enabled state, tooltip, and

--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -845,12 +845,22 @@ class EnhancementsTab(QWidget):
     # ── Status refresh ────────────────────────────────────────────────────────
 
     def refresh_enhancements_status(self):
-        """Update enhancement file status indicators and DataForge cache status."""
-        cache_dir = AppSettings.get_cache_dir()
+        """Update enhancement file status indicators and DataForge cache status.
+
+        Reads get_enhancements_dir() for the same reason
+        _compute_initial_enhancements_dirty does: the generator writes each
+        language's INIs to cache/lang/{language}, and only English collapses
+        onto the channel root. These dots sit directly beside the Generate
+        Enhancements button, so leaving them on get_cache_dir() while that
+        button reads the per-language dir let the two contradict each other
+        outright -- a German user with English enhancements generated saw
+        every category green AND the button lit, at the same time.
+        """
+        enh_dir = AppSettings.get_enhancements_dir()
         for key, dot in self._enhancements_status_labels.items():
             # Check all files controlled by this checkbox
             filenames = self._files_for_category(key)
-            all_present = all((cache_dir / fn).exists() for fn in filenames)
+            all_present = all((enh_dir / fn).exists() for fn in filenames)
             dot.setStyleSheet(f"color: {'#4caf50' if all_present else '#f44336'}; font-size: 12px;")
         self.refresh_forge_status()
 

--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -577,14 +577,28 @@ class EnhancementsTab(QWidget):
             now_enabled = cb.isChecked()
             AppSettings.set_enhancement_category_enabled(key, now_enabled)
 
-            cache_dir = AppSettings.get_cache_dir()
+            # Per-language, like every other enhancement-file path (#363).
+            # This one MUTATES files, so reading the channel root here did
+            # more than answer the wrong question: a user on a non-English
+            # language toggling a category renamed the ENGLISH INIs to
+            # .disabled and back, while their own language's files, the ones
+            # the checkbox appears to control, were never touched. The toggle
+            # silently did nothing for them and quietly vandalised English.
+            enh_dir = AppSettings.get_enhancements_dir()
             # Apply to all files mapped to this checkbox key
             for filename in self._files_for_category(key):
-                active_file = cache_dir / filename
-                disabled_file = cache_dir / (filename + ".disabled")
+                active_file = enh_dir / filename
+                disabled_file = enh_dir / (filename + ".disabled")
 
                 if not now_enabled and active_file.exists():
                     try:
+                        # Windows rename() fails when the target exists, and a
+                        # stale .disabled is reachable: anyone who hit the bug
+                        # above has an orphaned English .disabled, and
+                        # regenerating recreates the active file beside it.
+                        # Without this the next disable raises, gets logged,
+                        # and the toggle appears to do nothing.
+                        disabled_file.unlink(missing_ok=True)
                         active_file.rename(disabled_file)
                         logger.info(f"Disabled enhancement file: {filename}")
                     except OSError as e:

--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -411,7 +411,17 @@ class EnhancementsTab(QWidget):
     def _compute_initial_enhancements_dirty(self) -> bool:
         """True if Generate Enhancements has work to do right now: the
         DataForge cache was never extracted or is stale vs. Data.p4k, or an
-        enabled category's output file doesn't exist yet."""
+        enabled category's output file doesn't exist yet.
+
+        Looks in get_enhancements_dir(), not get_cache_dir(). Those are the
+        same path for English, but every other language keeps its generated
+        INIs in cache/lang/{language} (get_enhancements_dir), which is where
+        the generator writes them (workers.py, enh_dir). Checking the channel
+        root instead answered for English no matter which language was
+        selected, so a language with nothing generated could report "nothing
+        to do" purely because English had been generated earlier. #363 made
+        that reachable on every language switch, which is what surfaced it.
+        """
         from src.utils.pak_extractor import P4K_MTIME_STAMP, dataforge_cache_is_fresh
         forge_dir = AppSettings.get_dataforge_cache_dir()
         p4k_path = AppSettings.get_p4k_path()
@@ -419,10 +429,10 @@ class EnhancementsTab(QWidget):
             return True
         if p4k_path.exists() and not dataforge_cache_is_fresh(p4k_path, forge_dir):
             return True
-        cache_dir = AppSettings.get_cache_dir()
+        enh_dir = AppSettings.get_enhancements_dir()
         for key, cb in self._enhancements_checkboxes.items():
             if cb.isChecked() and any(
-                not (cache_dir / fn).exists() for fn in self._files_for_category(key)
+                not (enh_dir / fn).exists() for fn in self._files_for_category(key)
             ):
                 return True
         return False
@@ -535,13 +545,20 @@ class EnhancementsTab(QWidget):
         lights it for exactly that). Guarded with getattr so it stays a safe
         no-op if the enhancements group hasn't been built — setup_ui builds it
         before the Tag Builder group, so in practice it always has.
+
+        Uses get_enhancements_dir() so it agrees with the stamp it gates: the
+        stamp lives in that same per-language dir, and for anything but
+        English it is cache/lang/{language}, not the channel root. Reading the
+        root here would have suppressed the whole freshness check for a
+        non-English user who had never generated English enhancements — no
+        files found, so "nothing can be stale", so the stamp never read.
         """
         checkboxes = getattr(self, "_enhancements_checkboxes", None)
         if not checkboxes:
             return False
-        cache_dir = AppSettings.get_cache_dir()
+        enh_dir = AppSettings.get_enhancements_dir()
         return any(
-            (cache_dir / fn).exists()
+            (enh_dir / fn).exists()
             for key, cb in checkboxes.items() if cb.isChecked()
             for fn in self._files_for_category(key)
         )

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -4389,17 +4389,24 @@ class MainWindow(QMainWindow):
 
         Shows a category selection dialog on startup. If called again after P4K
         extraction and we already prompted, runs generation with saved selections.
+
+        Both paths below are per-language (#363). base.ini and the generated
+        INIs live under cache/lang/{language} for everything except English,
+        which alone collapses onto the channel root, so reading the root here
+        answered for English no matter which language was selected: a user on
+        German with English generated was never prompted to generate the
+        German set that did not exist.
         """
-        cache_dir = AppSettings.get_cache_dir()
-        if not (cache_dir / 'base.ini').exists():
+        if not AppSettings.get_base_ini_path().exists():
             return
         if self._enhancements_worker is not None or self._forge_worker is not None:
             return
 
         # Only check enabled categories
+        enh_dir = AppSettings.get_enhancements_dir()
         enabled = AppSettings.get_enabled_enhancement_categories()
         missing = [key for key in enabled
-                   if not (cache_dir / AppSettings.ENHANCEMENTS_FILES[key]).exists()]
+                   if not (enh_dir / AppSettings.ENHANCEMENTS_FILES[key]).exists()]
         if not missing:
             return
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -3925,6 +3925,16 @@ class MainWindow(QMainWindow):
         logger.info(f"MainWindow reacting to language change → {language}")
         self.retranslate_ui()
         self.statusBar().showMessage(tr("dialogs.language_changed_status", language=language))
+        # #363: both freshness buttons are per-language — enhancement INIs
+        # live in the language's own dir (get_enhancements_dir) and the tag
+        # config stamp sits beside them — but neither was recomputed here, so
+        # a switch left them showing the *previous* language's verdict. That
+        # is the same fault #273/#292 fixed for a channel switch, which
+        # _on_channel_changed handles with this identical pair of calls;
+        # language switching had simply never been wired up to match.
+        if hasattr(self, "enhancements_tab"):
+            self.enhancements_tab.refresh_enhancements_dirty_state()
+            self.enhancements_tab.refresh_tag_builder_dirty_state()
         # Point the `global` base source at this language's base.ini (English
         # = the P4K extraction; other languages = a downloaded global.ini),
         # downloading it first if needed, then reload. See #30.
@@ -4769,6 +4779,14 @@ class MainWindow(QMainWindow):
         self._enhancements_worker = None
         self.enhancements_tab.set_operation_idle(success)
         self.enhancements_tab.refresh_enhancements_status()
+        # #363: and the same for Save Tag Changes, which set_operation_idle
+        # doesn't cover. Both _apply_tag_builder and the Generate click
+        # handler clear that button the moment they *launch* a run, so a run
+        # that then fails left it grey over INIs the tag config never reached
+        # — the stamp is only written on success, so re-deriving from it here
+        # lights the button back up for a retry. On success the stamp matches
+        # what just generated and this leaves it grey, exactly as before.
+        self.enhancements_tab.refresh_tag_builder_dirty_state()
 
         if success:
             # #180: Simple-mode one-button flow continues into apply here.

--- a/tests/test_tag_builder_import_refresh.py
+++ b/tests/test_tag_builder_import_refresh.py
@@ -47,10 +47,39 @@ def qapp():
 
 @pytest.fixture
 def json_backend(tmp_path):
+    """Redirect BOTH the settings backend and the user data dir.
+
+    Swapping ``_backend`` alone leaves ``get_enhancements_dir()`` pointing at
+    the real ``Documents\\Smart Citizen\\{channel}\\cache``, because it derives
+    from the data-dir setting rather than the backend object. That went
+    unnoticed while nothing here read a file from it; the tag-config stamp
+    (#363) does, so without the redirect these tests would pass or fail
+    depending on whether the developer's own install happens to have a stamp
+    and whether it happens to match. ``set_user_data_dir`` writes through
+    ``settings()``, which is the swapped backend, so restoring ``_backend``
+    still undoes it.
+    """
     saved = AppSettings._backend
     AppSettings._backend = JsonSettings(tmp_path / "config.json")
+    AppSettings.set_user_data_dir(tmp_path / "data")
     yield AppSettings._backend
     AppSettings._backend = saved
+
+
+def _stamp_matching_current_config() -> None:
+    """Record the stamp a successful generation of the live config would leave,
+    i.e. put the generated INIs "in sync" for a freshness check."""
+    AppSettings.set_tag_config_stamp(AppSettings.get_current_tag_config_fingerprint())
+
+
+def _seed_generated_output() -> None:
+    """Put generated INIs on disk. The freshness check only reports staleness
+    when there is output that can actually be stale (#363), so a refresh over
+    an empty cache dir is unconditionally clean and would prove nothing."""
+    cache_dir = AppSettings.get_cache_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    for filename in AppSettings.ENHANCEMENTS_FILES.values():
+        (cache_dir / filename).write_text("; generated\n", encoding="utf-8")
 
 
 def _import_custom_configs():
@@ -106,14 +135,43 @@ class TestImportRefresh:
         tab.reload_tag_builder_from_settings()
         assert tab._annotate_mission_descs_cb.isChecked() is False
 
-    def test_refresh_leaves_save_button_clean(self, qapp, json_backend):
-        """Nothing is unsaved after a refresh, so the button must not light up."""
+    def test_refresh_leaves_save_button_clean_when_the_inis_match(
+            self, qapp, json_backend):
+        """A refresh must not light the button for *unsaved edits* — the pages
+        equal the persisted config by the time it returns, so there are none.
+
+        This used to assert an unconditional clean, which is what #363 changed:
+        the refresh now re-derives from the tag-config stamp instead of
+        asserting. Seeding a stamp that matches the imported config is what
+        makes "nothing to do" true rather than merely assumed, so the original
+        guarantee is still pinned — it just has to be set up honestly now.
+        """
         from src.gui.enhancements_tab import EnhancementsTab
 
         tab = EnhancementsTab()
+        _seed_generated_output()
         _import_custom_configs()
+        _stamp_matching_current_config()        # INIs already built from it
         tab.reload_tag_builder_from_settings()
         assert tab._tag_dirty is False
+
+    def test_refresh_lights_the_button_when_the_import_outdates_the_inis(
+            self, qapp, json_backend):
+        """#363, the Import Settings route into the reported bug.
+
+        An import that changes the tag config leaves the generated INIs built
+        from the *pre-import* one. Clearing the button unconditionally hid that
+        exactly as launch did: grey button, stale output, and no indication
+        anything needed regenerating.
+        """
+        from src.gui.enhancements_tab import EnhancementsTab
+
+        tab = EnhancementsTab()
+        _seed_generated_output()
+        _stamp_matching_current_config()        # generated against the OLD config
+        _import_custom_configs()                # ...which the import then changes
+        tab.reload_tag_builder_from_settings()
+        assert tab._tag_dirty is True
 
     def test_refresh_does_not_write_title_tags(self, qapp, json_backend):
         """The import path mirrors General Tags; it must not persist over them."""

--- a/tests/test_tag_builder_import_refresh.py
+++ b/tests/test_tag_builder_import_refresh.py
@@ -74,12 +74,16 @@ def _stamp_matching_current_config() -> None:
 
 def _seed_generated_output() -> None:
     """Put generated INIs on disk. The freshness check only reports staleness
-    when there is output that can actually be stale (#363), so a refresh over
-    an empty cache dir is unconditionally clean and would prove nothing."""
-    cache_dir = AppSettings.get_cache_dir()
-    cache_dir.mkdir(parents=True, exist_ok=True)
+    when there is output that can actually be stale (#363), so a refresh with
+    no output is unconditionally clean and would prove nothing.
+
+    get_enhancements_dir(), not get_cache_dir(): that is where the generator
+    writes and where the check looks (they differ for non-English languages).
+    """
+    enh_dir = AppSettings.get_enhancements_dir()
+    enh_dir.mkdir(parents=True, exist_ok=True)
     for filename in AppSettings.ENHANCEMENTS_FILES.values():
-        (cache_dir / filename).write_text("; generated\n", encoding="utf-8")
+        (enh_dir / filename).write_text("; generated\n", encoding="utf-8")
 
 
 def _import_custom_configs():

--- a/tests/test_tag_config_staleness_startup.py
+++ b/tests/test_tag_config_staleness_startup.py
@@ -1,0 +1,364 @@
+"""The Tag Builder freshness check has to run at startup, not only on a
+channel switch (#363).
+
+Reported as: the "annotate component tags in mission descriptions" checkbox
+reads enabled, but the annotations are absent in game. Turning it off, letting
+the regeneration finish, and turning it back on fixes it — which is a strange
+shape for a settings bug, because the setting was already the value the user
+wanted both before and after.
+
+It isn't a settings bug. The value was always right; what was never checked is
+whether the *generated INIs on disk* were built from it. Three staleness
+signals exist, and only two of them were consulted at launch:
+
+    DataForge cache vs Data.p4k        checked at startup
+    enhancement output files missing   checked at startup
+    tag config vs the config the       ONLY on a channel switch
+      INIs were generated from
+
+That third one is where the annotate toggle lives.
+``refresh_tag_builder_dirty_state()`` implements it correctly — light Save Tag
+Changes when the recorded stamp is missing or differs from the live config —
+but ``setup_ui`` ended with an unconditional ``_set_tag_btn_dirty(False)``, so
+launch asserted "clean" instead of asking. With the output files present and
+the DataForge cache current, Generate Enhancements sat grey too (it asks "does
+the file exist", not "was it built from this config"), leaving both buttons
+grey over stale output and no indication anything was wrong.
+
+Cycling the checkbox worked because ``_mark_tag_dirty`` is a blind "the user
+touched a control" flag, not a comparison: the cycle forged the dirty state
+that the startup check should have derived. test_cycling_the_checkbox_never_
+changed_the_config pins that, since it is the whole reason the workaround
+looked like it was re-registering a setting.
+
+Every install upgraded from before the stamp existed has no stamp at all (it
+and the annotate flag joining the fingerprint landed in the same commit), so
+the missing-stamp case below is not an edge case — it is what every upgrading
+user gets on first launch.
+
+Needs a real QApplication for the widgets, so it uses the offscreen Qt platform
+like tests/test_ui_mode.py rather than pytest-qt (not a dev dep).
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtCore import QSettings  # noqa: E402
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+# Same import path src/gui/enhancements_tab.py uses, so patching
+# AppSettings.settings affects the exact class the tab sees (see the note in
+# tests/test_ui_mode.py about the dual pythonpath).
+from src.utils.settings import AppSettings  # noqa: E402
+from src.utils.tag_builder import tag_config_fingerprint  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture
+def isolated_settings(tmp_path, monkeypatch):
+    """Redirect the settings store AND the user data dir.
+
+    The data dir matters here specifically: the tag-config stamp is a file
+    under ``get_enhancements_dir()``, which derives from the data-dir setting
+    rather than from the settings object. Patching only ``settings`` would
+    leave these tests reading the developer's own install and passing or
+    failing on whether it happens to hold a matching stamp.
+    """
+    shared = QSettings(str(tmp_path / "reg.ini"), QSettings.Format.IniFormat)
+    monkeypatch.setattr(AppSettings, "settings", staticmethod(lambda: shared))
+    AppSettings.set_user_data_dir(tmp_path / "data")
+    return tmp_path
+
+
+def _new_tab():
+    from src.gui.enhancements_tab import EnhancementsTab
+    return EnhancementsTab()
+
+
+def _stamp_for(annotate: bool) -> None:
+    """Record the stamp a successful generation would leave for the persisted
+    tag configs combined with *annotate*."""
+    AppSettings.set_tag_config_stamp(
+        tag_config_fingerprint(AppSettings.get_all_tag_configs(), annotate)
+    )
+
+
+def _stamp_matching_live_config() -> None:
+    _stamp_for(AppSettings.get_tag_annotate_mission_descs())
+
+
+def _seed_generated_output() -> None:
+    """Put generated INIs on disk, so there is output a tag-config change can
+    actually invalidate.
+
+    Every check below needs this: being stale requires something that *can* be
+    stale, and with an empty cache dir the button stays grey by design (see
+    test_no_generated_output_means_nothing_can_be_stale). Writes the whole
+    ENHANCEMENTS_FILES set rather than picking the enabled ones, so the tests
+    don't quietly depend on which categories default to on.
+    """
+    cache_dir = AppSettings.get_cache_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    for filename in AppSettings.ENHANCEMENTS_FILES.values():
+        (cache_dir / filename).write_text("; generated\n", encoding="utf-8")
+
+
+# ── The startup check ───────────────────────────────────────────────────────
+
+def test_missing_stamp_lights_the_button_at_construction(qapp, isolated_settings):
+    """What every install upgraded from before the stamp existed looks like:
+    INIs on disk, nothing recording what they were built from. Unknowable
+    reads as stale, matching the rule the channel-switch path already used."""
+    _seed_generated_output()
+    assert AppSettings.get_tag_config_stamp() == ""
+    assert _new_tab()._tag_dirty is True
+
+
+def test_stale_stamp_lights_the_button_at_construction(qapp, isolated_settings):
+    _seed_generated_output()
+    AppSettings.set_tag_config_stamp("built-from-some-older-config")
+    assert _new_tab()._tag_dirty is True
+
+
+def test_matching_stamp_leaves_the_button_clean_at_construction(
+        qapp, isolated_settings):
+    """The other half of the contract, and the one that keeps this fix from
+    being "light the button always": when the INIs really were generated from
+    the live config there is nothing to do and the button stays grey."""
+    _seed_generated_output()
+    _stamp_matching_live_config()
+    assert _new_tab()._tag_dirty is False
+
+
+def test_annotate_toggle_alone_makes_the_output_stale(qapp, isolated_settings):
+    """The reported symptom, reduced to one setting.
+
+    The INIs were generated while annotation was off; the checkbox now reads
+    on (its default). Nothing else differs. That difference alone has to reach
+    the button, because it is the only thing standing between the user and
+    annotations that silently never appear in game.
+    """
+    _seed_generated_output()
+    _stamp_for(annotate=False)
+    tab = _new_tab()
+    assert tab._annotate_mission_descs_cb.isChecked() is True
+    assert tab._tag_dirty is True
+
+
+def test_no_generated_output_means_nothing_can_be_stale(qapp, isolated_settings):
+    """The bound on the whole check: being stale requires something that can
+    *be* stale.
+
+    A brand-new install has no stamp, which reads as "unknowable" and would
+    otherwise light the button before the user has done anything wrong. There
+    are no INIs to be out of date, and Generate Enhancements is already lit for
+    the missing files, so a second red button would be noise.
+    """
+    assert AppSettings.get_tag_config_stamp() == ""      # nothing generated
+    assert _new_tab()._tag_dirty is False
+
+
+def test_export_settings_keeps_the_button_lit_when_output_is_behind(
+        qapp, isolated_settings):
+    """flush_pending_tag_edits (Export Settings) persists on-screen edits
+    *without* regenerating, so it must not clear the button.
+
+    It used to, which threw away a correct signal the user had already been
+    shown: edit the Tag Builder, click Export Settings, and the edits landed in
+    settings while the INIs kept the old config — the same stale-output-behind-
+    a-grey-button end state as launch and import.
+    """
+    _seed_generated_output()
+    _stamp_matching_live_config()
+    tab = _new_tab()
+    assert tab._tag_dirty is False                       # in sync to begin with
+
+    tab._annotate_mission_descs_cb.setChecked(            # an unsaved edit
+        not tab._annotate_mission_descs_cb.isChecked()
+    )
+    assert tab._tag_dirty is True
+
+    tab.flush_pending_tag_edits()                         # Export Settings
+    assert tab._tag_dirty is True, (
+        "the edit is saved but the INIs were never regenerated, so the user "
+        "still needs to act"
+    )
+
+
+def test_startup_state_agrees_with_the_freshness_check(qapp, isolated_settings):
+    """The bug stated as an invariant: launch must not contradict the app's own
+    definition of stale.
+
+    Before the fix, constructing the tab and then running the freshness check
+    flipped the button — the startup state and the check disagreed, and only
+    a channel switch ever ran the check to settle it. Asserting they agree
+    catches a regression whichever side of the pair drifts.
+    """
+    _seed_generated_output()
+    for stamp in ("", "built-from-some-older-config"):
+        AppSettings.set_tag_config_stamp(stamp)
+        tab = _new_tab()
+        at_construction = tab._tag_dirty
+        tab.refresh_tag_builder_dirty_state()
+        assert at_construction is tab._tag_dirty, (
+            f"startup state contradicts the freshness check for stamp {stamp!r}"
+        )
+
+    _stamp_matching_live_config()
+    tab = _new_tab()
+    at_construction = tab._tag_dirty
+    tab.refresh_tag_builder_dirty_state()
+    assert at_construction is tab._tag_dirty
+
+
+def test_cycling_the_checkbox_never_changed_the_config(qapp, isolated_settings):
+    """Documents why the reporter's workaround appeared to re-register the
+    setting: it didn't. An off/on cycle lands on the identical config, so the
+    button lighting up afterwards was purely ``_mark_tag_dirty`` firing on the
+    toggle — a blind "user touched something" flag. The startup check now
+    reaches the same conclusion without needing to be poked."""
+    _seed_generated_output()
+    _stamp_for(annotate=False)
+    tab = _new_tab()
+    before = tab._live_tag_config_fingerprint()
+
+    tab._annotate_mission_descs_cb.setChecked(False)
+    tab._annotate_mission_descs_cb.setChecked(True)
+
+    assert tab._live_tag_config_fingerprint() == before
+    assert tab._tag_dirty is True
+
+
+# ── Re-deriving after a generation run ──────────────────────────────────────
+#
+# _apply_tag_builder and the Generate click handler both clear the button the
+# moment they *launch* a run, before the worker has done anything. The stamp
+# is only written on success, so a failed run used to leave the button grey
+# over INIs the tag config never reached. MainWindow's finished handler now
+# re-derives it, the same way set_operation_idle already does for the Generate
+# button (which it does not cover).
+#
+# Driven on a lightweight stand-in `self` with the real unbound method, per
+# tests/test_ui_mode.py — constructing a whole MainWindow pulls in the full
+# startup pipeline. The enhancements_tab is a real one, since its button state
+# is the thing under test.
+
+class _StubWorker:
+    def quit(self):
+        pass
+
+    def wait(self):
+        pass
+
+
+class _StubStatusBar:
+    def showMessage(self, *_args, **_kwargs):
+        pass
+
+
+class _StubWindow:
+    """Only the attributes _on_enhancements_generation_finished touches."""
+
+    def __init__(self, tab):
+        self.enhancements_tab = tab
+        self._enhancements_progress_dialog = None
+        self._enhancements_worker = _StubWorker()
+        self._simple_run_active = False
+
+    def statusBar(self):
+        return _StubStatusBar()
+
+    def _show_loading_progress(self, *_args):
+        pass
+
+    def _end_simple_run(self):
+        pass
+
+
+def _finish_generation(tab, success: bool):
+    from src.gui.main_window import MainWindow
+    MainWindow._on_enhancements_generation_finished(_StubWindow(tab), success)
+
+
+def test_failed_generation_relights_the_optimistically_cleared_button(
+        qapp, isolated_settings):
+    _seed_generated_output()
+    AppSettings.set_tag_config_stamp("built-from-some-older-config")
+    tab = _new_tab()
+    assert tab._tag_dirty is True
+
+    tab._set_tag_btn_dirty(False)        # what launching a run does
+    _finish_generation(tab, success=False)
+
+    assert tab._tag_dirty is True, (
+        "a failed run leaves the stamp untouched, so the button has to come "
+        "back for a retry rather than sitting grey over stale INIs"
+    )
+
+
+def test_language_switch_re_derives_both_freshness_buttons(qapp, isolated_settings):
+    """Both buttons are per-language — enhancement INIs live in the language's
+    own dir and the tag-config stamp sits beside them — so a language switch
+    has to recompute them or they keep showing the previous language's verdict.
+
+    _on_channel_changed already does exactly this pair of calls; language
+    switching had never been wired up to match. A wiring test rather than a
+    state one: the state logic is covered above, what was missing is the call.
+    """
+    from src.gui.main_window import MainWindow
+
+    called = []
+
+    class _RecordingTab:
+        def refresh_enhancements_dirty_state(self):
+            called.append("enhancements")
+
+        def refresh_tag_builder_dirty_state(self):
+            called.append("tag_builder")
+
+    class _Window:
+        _loader_worker = None
+        enhancements_tab = _RecordingTab()
+
+        def retranslate_ui(self):
+            pass
+
+        def statusBar(self):
+            return type("_Bar", (), {"showMessage": lambda *a, **k: None})()
+
+        def _apply_language_base_source(self, language):
+            pass
+
+    MainWindow._on_language_changed(_Window(), "english")
+
+    assert called == ["enhancements", "tag_builder"]
+
+
+def test_successful_generation_leaves_the_button_clean(qapp, isolated_settings):
+    """The non-regression half: a run that really did write a matching stamp
+    must settle the button, not re-light it."""
+    _seed_generated_output()
+    AppSettings.set_tag_config_stamp("built-from-some-older-config")
+    tab = _new_tab()
+    assert tab._tag_dirty is True
+
+    _stamp_matching_live_config()        # what a successful worker writes
+    _finish_generation(tab, success=True)
+
+    assert tab._tag_dirty is False

--- a/tests/test_tag_config_staleness_startup.py
+++ b/tests/test_tag_config_staleness_startup.py
@@ -108,15 +108,21 @@ def _seed_generated_output() -> None:
     actually invalidate.
 
     Every check below needs this: being stale requires something that *can* be
-    stale, and with an empty cache dir the button stays grey by design (see
+    stale, and with no output the button stays grey by design (see
     test_no_generated_output_means_nothing_can_be_stale). Writes the whole
     ENHANCEMENTS_FILES set rather than picking the enabled ones, so the tests
     don't quietly depend on which categories default to on.
+
+    Writes into get_enhancements_dir(), which is where the generator puts them
+    and where the app looks. That is the same path as get_cache_dir() for
+    English and cache/lang/{language} for everything else, so seeding the
+    channel root instead would have made the non-English tests below pass for
+    the wrong reason.
     """
-    cache_dir = AppSettings.get_cache_dir()
-    cache_dir.mkdir(parents=True, exist_ok=True)
+    enh_dir = AppSettings.get_enhancements_dir()
+    enh_dir.mkdir(parents=True, exist_ok=True)
     for filename in AppSettings.ENHANCEMENTS_FILES.values():
-        (cache_dir / filename).write_text("; generated\n", encoding="utf-8")
+        (enh_dir / filename).write_text("; generated\n", encoding="utf-8")
 
 
 # ── The startup check ───────────────────────────────────────────────────────
@@ -172,6 +178,51 @@ def test_no_generated_output_means_nothing_can_be_stale(qapp, isolated_settings)
     """
     assert AppSettings.get_tag_config_stamp() == ""      # nothing generated
     assert _new_tab()._tag_dirty is False
+
+
+# ── Non-English languages ───────────────────────────────────────────────────
+#
+# get_enhancements_dir() is get_cache_dir() for English but
+# cache/lang/{language} for everything else, and the generator writes the INIs
+# (and the stamp beside them) into that per-language dir. Every check here
+# therefore has to use get_enhancements_dir(); reading the channel root answers
+# for English no matter which language is selected.
+#
+# These went unwritten first time round and the whole fix was inert for
+# non-English users as a result: the output-exists gate found nothing under the
+# channel root, concluded "nothing can be stale", and returned before ever
+# reading the stamp. Every other test in this file runs at English, where the
+# two paths coincide, so none of them could see it.
+
+def test_stale_stamp_lights_the_button_on_a_non_english_language(
+        qapp, isolated_settings):
+    AppSettings.set_selected_language("german")
+    assert AppSettings.get_enhancements_dir() != AppSettings.get_cache_dir(), (
+        "precondition: the per-language dir must differ from the channel root, "
+        "or this test collapses into the English case and proves nothing"
+    )
+    _seed_generated_output()
+    AppSettings.set_tag_config_stamp("built-from-some-older-config")
+
+    assert _new_tab()._tag_dirty is True
+
+
+def test_english_output_does_not_vouch_for_another_language(
+        qapp, isolated_settings):
+    """The precise failure: English enhancements exist, German ones do not.
+
+    Both the output-exists gate and the Generate Enhancements check used to
+    read the channel root, so English's files answered for German. The gate
+    said "there is output, so staleness is meaningful" and Generate said
+    "everything is present, nothing to do", neither of which is true of the
+    language actually selected.
+    """
+    _seed_generated_output()                    # English, at the channel root
+    AppSettings.set_selected_language("german")  # ...which has nothing generated
+
+    tab = _new_tab()
+    assert tab._enhancements_output_exists() is False
+    assert tab._compute_initial_enhancements_dirty() is True
 
 
 def test_export_settings_keeps_the_button_lit_when_output_is_behind(

--- a/tests/test_tag_config_staleness_startup.py
+++ b/tests/test_tag_config_staleness_startup.py
@@ -225,6 +225,36 @@ def test_english_output_does_not_vouch_for_another_language(
     assert tab._compute_initial_enhancements_dirty() is True
 
 
+def test_status_dots_and_generate_button_agree_on_a_non_english_language(
+        qapp, isolated_settings):
+    """The category dots sit directly beside the Generate Enhancements button,
+    so they have to answer the same question about the same directory.
+
+    Making only the button language-aware left the two contradicting each
+    other outright: with English enhancements generated and German selected,
+    every dot rendered green ("all present", read from the channel root where
+    English lives) while the button was simultaneously lit ("work to do",
+    correctly reading the empty per-language dir). Consistently wrong at least
+    agreed; half-fixed did not.
+    """
+    _seed_generated_output()                     # English, at the channel root
+    AppSettings.set_selected_language("german")   # ...which has nothing generated
+
+    tab = _new_tab()
+    tab.refresh_enhancements_status()
+    tab.refresh_enhancements_dirty_state()
+
+    green = sum(
+        "#4caf50" in dot.styleSheet()
+        for dot in tab._enhancements_status_labels.values()
+    )
+    assert green == 0, (
+        "dots report English's files while the button reports German's; "
+        "they must read the same directory"
+    )
+    assert tab._generate_enhancements_btn.isEnabled() is True
+
+
 def test_export_settings_keeps_the_button_lit_when_output_is_behind(
         qapp, isolated_settings):
     """flush_pending_tag_edits (Export Settings) persists on-screen edits

--- a/tests/test_tag_config_staleness_startup.py
+++ b/tests/test_tag_config_staleness_startup.py
@@ -255,6 +255,62 @@ def test_status_dots_and_generate_button_agree_on_a_non_english_language(
     assert tab._generate_enhancements_btn.isEnabled() is True
 
 
+def test_category_toggle_renames_the_selected_language_not_english(
+        qapp, isolated_settings):
+    """_apply_category_changes MUTATES files, so reading the channel root did
+    more than answer the wrong question.
+
+    A user on German unticking a category renamed the ENGLISH INIs to
+    .disabled and back, while the German files the checkbox appears to control
+    were never touched: the toggle silently did nothing for them and quietly
+    vandalised English along the way.
+    """
+    english_dir = AppSettings.get_cache_dir()
+    _seed_generated_output()                      # English, at the channel root
+    AppSettings.set_selected_language("german")
+    _seed_generated_output()                      # ...and German, in its own dir
+    german_dir = AppSettings.get_enhancements_dir()
+    assert german_dir != english_dir
+
+    tab = _new_tab()
+    key = next(k for k, cb in tab._enhancements_checkboxes.items() if cb.isChecked())
+    filenames = tab._files_for_category(key)
+    tab._enhancements_checkboxes[key].setChecked(False)
+    tab._apply_category_changes()
+
+    for fn in filenames:
+        assert (german_dir / (fn + ".disabled")).exists(), f"{fn} not disabled for german"
+        assert not (german_dir / fn).exists()
+        assert (english_dir / fn).exists(), f"english {fn} must be untouched"
+        assert not (english_dir / (fn + ".disabled")).exists()
+
+
+def test_category_toggle_survives_a_stale_disabled_file(qapp, isolated_settings):
+    """Windows rename() fails when the target exists, and a stale .disabled is
+    reachable: anyone who hit the bug above has an orphaned one, and
+    regenerating recreates the active file beside it. The rename then raised,
+    got swallowed by the OSError handler, and the toggle appeared to do
+    nothing at all."""
+    _seed_generated_output()
+    enh_dir = AppSettings.get_enhancements_dir()
+
+    tab = _new_tab()
+    key = next(k for k, cb in tab._enhancements_checkboxes.items() if cb.isChecked())
+    filenames = tab._files_for_category(key)
+    for fn in filenames:                          # the orphan from the old bug
+        (enh_dir / (fn + ".disabled")).write_text("; stale\n", encoding="utf-8")
+
+    tab._enhancements_checkboxes[key].setChecked(False)
+    tab._apply_category_changes()
+
+    for fn in filenames:
+        assert not (enh_dir / fn).exists(), f"{fn} should have been disabled"
+        assert (enh_dir / (fn + ".disabled")).read_text(encoding="utf-8") != "; stale\n", (
+            "the stale orphan should have been replaced by the real file, "
+            "not left in place with the rename silently failing"
+        )
+
+
 def test_export_settings_keeps_the_button_lit_when_output_is_behind(
         qapp, isolated_settings):
     """flush_pending_tag_edits (Export Settings) persists on-screen edits


### PR DESCRIPTION
Fixes #363.

## The report

The "annotate component tags in mission descriptions" checkbox read enabled, but the annotations were absent in game. Erelaszun found that turning it off, letting the generation finish, then turning it back on fixed it, and guessed that the checkbox "doesn't register as enabled until its cycled".

The setting always registered. What was never checked is whether the generated INIs on disk were built from it.

## Root cause

Three staleness signals exist. Only two of them were consulted at launch:

| Signal | At startup | On channel switch |
| --- | --- | --- |
| DataForge cache vs `Data.p4k` | yes | yes |
| enhancement output files missing | yes | yes |
| **tag config vs the config the INIs were generated from** | **no** | yes |

The annotate toggle lives entirely in that third row. `refresh_tag_builder_dirty_state()` implements it correctly, lighting Save Tag Changes when the recorded stamp is missing or differs from the live config, but it was wired to exactly one caller: `_on_channel_changed`. At launch, `setup_ui` ended with an unconditional `_set_tag_btn_dirty(False)`.

So the button was grey at startup regardless of whether the files on disk matched the setting. Generate Enhancements was grey too, because `_compute_initial_enhancements_dirty()` only asks whether the output file exists, never whether it was built from this config. Two grey buttons over stale output, and nothing saying anything was wrong.

Cycling the checkbox worked because `_mark_tag_dirty` is a blind "the user touched a control" flag rather than a comparison. The config fingerprint is identical before and after an off/on cycle; the cycle simply forged the dirty state the startup check should have derived.

Reproduced with a real window against a seeded profile (generation complete, stamp from an older config):

```
annotate checkbox ticked        : True
output is stale per the app     : True
Generate Enhancements enabled   : False
Save Tag Changes enabled        : False     <- no way to act
```

Every install upgraded from before the stamp existed has no stamp at all, since the stamp and the annotate flag joining the fingerprint landed in the same commit. This is not an edge case, it is what upgrading users get.

## What changed

Every point that can invalidate the generated INIs now re-derives the button instead of asserting a state:

- **Launch** (`setup_ui`), the reported bug.
- **Import Settings** (`reload_tag_builder_from_settings`), which cleared the button after an import that changed the config, leaving the INIs built from the pre-import one.
- **Export Settings** (`flush_pending_tag_edits`), which persists on-screen edits without regenerating, and threw away a red button the user had already been shown.
- **A finished run**, since both trigger paths clear the button the moment they launch one. A run that then failed left it grey over INIs the tag config never reached; the stamp is only written on success, so re-deriving relights it for a retry.
- **A language switch**, which recomputed neither freshness button even though the INIs and the stamp are both per-language. `_on_channel_changed` already made this exact pair of calls, language switching had simply never been wired up to match.

Fixing only the launch case would have left the same bug reachable four other ways, which is why the change is wider than the report.

One behaviour bound comes with it: being stale requires something that can be stale, so the check reports clean when no enhancement output exists at all. Otherwise a brand new install, which has no stamp and therefore reads as unknowable, would show a red Save Tag Changes before the user had done anything, alongside the Generate Enhancements button already lit for the missing files.

## Testing

`tests/test_tag_config_staleness_startup.py` (new) covers the startup states, the annotate toggle in isolation, the no-output gate, Export Settings, the language switch, and both generation outcomes. Nine assertions across the two test files fail against the unfixed source, so none of them are vacuous. Full suite: 1587 passed, 21 skipped.

`tests/test_tag_builder_import_refresh.py`'s fixture now redirects the user data dir as well as the settings backend. Swapping the backend alone left `get_enhancements_dir()` pointing at the developer's real install, which is where the stamp is read from, so stamp assertions would have passed or failed depending on the machine. Its `test_refresh_leaves_save_button_clean` is renamed and seeds a matching stamp, because "a refresh always clears the button" was the behaviour being fixed. The guarantee it protects, that a refresh must not light the button for unsaved edits, is still pinned.

Verified in a portable build: a fresh unzip leaves Save Tag Changes grey and only Generate Enhancements lit, and the Import Settings route above turns Save Tag Changes red once there is output to be stale.

## Note for merging: #358 conflicts with #355

This PR touches neither, but the integration build used to test it had to exclude #358, and the reason is worth flagging before either is merged.

#355 (`enclosings=`) and #358 (`bp_header=`) each add a **different** new keyword parameter to an overlapping set of functions:

| Function | #355 adds | #358 adds |
| --- | --- | --- |
| `owned_items.extract_bp_item_names` | `enclosings=` | `bp_header=` |
| `owned_items.apply_owned_to_value` | `enclosings=` | `bp_header=` |
| `blueprint_meta.build_blueprint_metadata` | `enclosings=` | `bp_header=` |
| `entry_filter.filter_entry_indices` | body only | `bp_header=` |

Whichever merges second will conflict in `src/gui/main_window.py`, `src/utils/blueprint_meta.py`, `src/utils/entry_filter.py` and `src/utils/owned_items.py`.

The resolution is mechanical rather than a design decision. The two parameters are orthogonal, one being the bracket style used to strip a tag and the other a renamed "blueprints" section header, so both should be kept and threaded through together. `#355`'s `enclosings_from_tag_configs()` and `#358`'s `_build_bp_header_re()` both survive unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
