### PR TITLE
Skip the Claude review workflow on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,14 @@ on:
 
 jobs:
   claude-review:
+    # Repository secrets are withheld from `pull_request` runs that
+    # originate in a fork, so `claude_code_oauth_token` below resolves to
+    # an empty string and the run fails on auth rather than on the code.
+    # Skip those cleanly instead of reporting a red X on every external
+    # PR. Branches pushed to this repo still run, which is the normal
+    # flow -- every regular contributor here has write access.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Problem

`claude-code-review.yml` has been failing on every open 2.3.1 PR. The cause is not the token — `CLAUDE_CODE_OAUTH_TOKEN` is set correctly on the repo.

Every open PR originates in a fork (`Stealrull/smart-citizen`), and GitHub deliberately withholds repository secrets from `pull_request` runs that come from a fork. So `secrets.CLAUDE_CODE_OAUTH_TOKEN` resolves to an empty string, which is exactly what the run log shows:

```
"claude_code_oauth_token": "",
```

The action then fails on auth, producing a red X that says nothing about the code under review.

## Change

One job-level guard:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

Fork PRs now skip cleanly instead of failing. Branches pushed to this repo still run — and that is the normal path, since every regular contributor here already has write access.

`claude.yml` needs no equivalent guard: it triggers on `issue_comment`, `pull_request_review_comment`, `issues` and `pull_request_review`, all of which run in the base-repo context with secrets available even for a fork PR.

## Verification

- YAML parses; both steps and the trigger list are unchanged, only the `if` was added.
- Diff is 8 added lines, 0 removed.

## Note

This does not restore automated review *on* fork PRs — it stops them failing. If the goal is to have the review run on Stealrull's PRs, the better fix is for those branches to be pushed to this repo rather than to a fork; `pull_request_target` would also work but would put the token in a job reviewing fork-authored code, which is a real risk given the prompt posts comments back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)