### PR TITLE
Test Plan: cover the hidden-selection guard (#374 review)

### DIFF
--- a/src/utils/test_plan.py
+++ b/src/utils/test_plan.py
@@ -71,6 +71,7 @@ TEST_SECTIONS: list[dict] = [
             "Clear every filter: both lists show all of their items again.",
             "No component appears in Available and Owned at the same time (the \"stacking\" report).",
             "Commodity crafting-material lines (e.g. \"Power Plants: 10 items\") never show up as fake blueprint items in either list.",
+            "In Owned, select several items, then type in the search box so only one stays visible, and click Remove: only the visible one is un-owned.",
         ],
     },
     {


### PR DESCRIPTION
Found by `/pre_release` step 4 (Test Plan currency).

#377 rewrote the Test Plan for the 2.3.1 scope, but #376 landed after it — including `bd00c83 Exclude hidden rows from selection (#374 review)`, the fix for a defect raised in review where a selection made *before* filtering could let **Remove** silently un-own items the user could no longer see.

The existing `Blueprint Tracker lists and filters (#354, #374)` section covers the filtering itself but nothing exercises that guard. Adding one item:

> In Owned, select several items, then type in the search box so only one stays visible, and click Remove: only the visible one is un-owned.

138 characters, inside the documented ~190 limit that `tests/test_test_plan.py` enforces via its 200-char chunking assertion.

Worth a tester item because the failure mode is silent — when the guard works there is nothing to see, and if it regresses a tester loses part of their own owned list without noticing.

`plan_hash()` changes with the content, so stale check-marks drop rather than re-pointing at different items.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)