### PR TITLE
Add the 2.3.1 release notes

### DIFF
--- a/docs/2.3.1-RELEASE-NOTES.md
+++ b/docs/2.3.1-RELEASE-NOTES.md
@@ -1,0 +1,63 @@
+# Smart Citizen 2.3.1
+
+> ⚠️ **Heads-up if Windows blocks the installer:** Smart Citizen is not yet code-signed, and Windows 11's **Smart App Control** (SAC) blocks unsigned installers, Properties → Unblock does **not** help with SAC. To install:
+>
+> 1. Open **Settings → Privacy & security → Windows Security → App & browser control**.
+> 2. Click **Smart App Control settings** and set it to **Off**.
+> 3. Run `SmartCitizen-2.3.1-Setup.exe` and finish installation.
+> 4. After install, you can return to the same screen and turn Smart App Control back on if you'd like.
+>
+> A code-signing certificate would remove this friction permanently. Smart Citizen is a free side project, so signing will only happen if community donations cover the recurring cost, **or** if Smart Citizen reaches enough adoption to qualify for a free certificate through the [SignPath Foundation](https://signpath.org/) open-source endorsement program. Until then: SAC-off install, SAC-on after.
+
+---
+
+## Headline
+
+Hey Smart Citizens! 2.3.1 is a bug-fix release, and almost all of it came from you reporting things that were quietly broken. The **Blueprint Tracker** got the most attention: several ways it could show an empty or wrong list are fixed. The window also **resizes freely** now, with **String Editor columns you can drag**, which was the most-asked-for thing that wasn't a bug.
+
+## The window resizes properly now
+
+Below full screen, some tabs had content squeezed or cut off with no way to reach it. Every tab now scrolls its own content, so you can drag the window to whatever size suits your screen and still get at everything.
+
+That opened the door to two more things:
+
+- **Drag the String Editor columns.** Grab the divider between two column headers and pull. Double-click a divider to snap that column to the width of its widest visible content. Your widths are remembered between launches.
+- **Until you resize one yourself**, Smart Citizen keeps fitting the columns to your window automatically, so a fresh install still opens sensibly on any screen.
+
+Window size and panel layout persist too. If it all ends up somewhere awkward, **More → Reset Window Proportions** puts it back. That only touches sizes, your settings, edits, and localization data are left alone.
+
+Simple mode also stopped opening with a scrollbar over a page that had room to spare.
+
+## Blueprint Tracker
+
+Four separate reports, four different ways the tracker could mislead you.
+
+- **Tags other than square brackets work again.** If you set the Tag Builder to Round, Curly, Angle, or None, the tracker stopped recognising your items entirely, no Class, Size, or Grade, nothing to filter on. Ship weapons and components like QuadraCell and the FR-66 were the usual casualties. All five styles work now, including None (space only), which needed a different approach because there are no brackets to find.
+- **Renaming the blueprints header no longer empties the tracker.** If you renamed **POTENTIAL BLUEPRINTS** in Config → Mission Labels, the tracker stopped populating completely, not just partly. It follows your name now, and the String Editor's BP Descriptions filter does too.
+- **Blueprints from another localization editor are recovered.** If you have ever run a different editor, Star Citizen's logs permanently carry that tool's naming, so names like `Ind/1/B Colossus` never matched anything here and those blueprints never showed as owned. Reinstalling didn't help, because the names live in your logs rather than in anything Smart Citizen writes. Launch once and they are repaired automatically. Anything Smart Citizen can't confidently identify is left alone rather than deleted.
+- **Filters apply to the Owned list.** The search box and the Type, Class, Size, Grade, and Mission dropdowns only ever narrowed the Available side. Finding one component among hundreds you own meant scrolling.
+
+Also: components no longer appear stacked in the Owned list, and two unrelated Rayari research missions (the Yormandi Eye and Irradiated Valakkar Pearl variants) stopped merging their reward lists into one.
+
+## When Smart Citizen reads the wrong game folder
+
+One user's DataForge extraction hung for thirty minutes, every run. Their game was fine. Smart Citizen was reading a **leftover Star Citizen install** on another drive, which still looked valid but held years-old game data.
+
+Smart Citizen now picks the install with the newest `Data.p4k`, which is the one the launcher is actually keeping up to date, and writes every candidate it found to the log.
+
+If extraction does time out, the message now names the exact folder it was reading and tells you to check that against the RSI Launcher, rather than sending you to Verify Files. In this case Verify Files could never have helped, the launcher was dutifully verifying the install Smart Citizen wasn't using.
+
+One thing worth knowing: if an earlier version already saved the wrong folder, this doesn't repair it, Smart Citizen keeps using the path you have saved. Check **Config → Star Citizen Install Path** against the launcher, and correct it there if they disagree.
+
+## Fixes and polish
+
+- **Component tags in mission rewards now appear without cycling the checkbox.** If **annotate component tags in mission descriptions** read enabled but the tags weren't in game, the setting was fine, the files on disk were just built before you turned it on. Smart Citizen now notices that at startup and asks you to regenerate, instead of only checking when you switch channels.
+- **The filter row no longer covers the column names** after a reload. It could sit on top of the headers until you resized something.
+- **Horizontal scrolling is smooth.** It used to jump a whole column per step.
+- **The Log tab's scrollbar** lines up with every other tab's.
+
+## After you update
+
+Run **Generate Enhancements** once after installing, then **Apply Enhancements** as usual. Several of the tracker fixes change how names and tags are built, and regenerating is what picks them up.
+
+If your Blueprint Tracker has been showing items you don't own, or missing ones you do, this is the release that should sort it. If it still looks wrong afterwards, say so on Discord, that is how every fix in this list got found.

--- a/docs/2.3.1-RELEASE-NOTES.md
+++ b/docs/2.3.1-RELEASE-NOTES.md
@@ -11,6 +11,13 @@
 
 ---
 
+## Download
+
+- **[SmartCitizen-2.3.1-Setup.exe](https://github.com/Osiris-DevWorks/smart-citizen/releases/download/v2.3.1/SmartCitizen-2.3.1-Setup.exe)** — the installer, and what most people want. Auto-detects your Star Citizen install and sets up the auto-updater.
+- **[SmartCitizen-Portable-v2.3.1.zip](https://github.com/Osiris-DevWorks/smart-citizen/releases/download/v2.3.1/SmartCitizen-Portable-v2.3.1.zip)** — no install, no registry. Unzip and run the `.exe`; it keeps its settings in a `data` folder beside itself. This is also the build to use [on Linux through Wine](https://github.com/Osiris-DevWorks/smart-citizen/blob/main/docs/LINUX.md).
+
+Already running Smart Citizen? It checks for updates at launch and will offer to install this one for you.
+
 ## Headline
 
 Hey Smart Citizens! 2.3.1 is a bug-fix release, and almost all of it came from you reporting things that were quietly broken. The **Blueprint Tracker** got the most attention: several ways it could show an empty or wrong list are fixed. The window also **resizes freely** now, with **String Editor columns you can drag**, which was the most-asked-for thing that wasn't a bug.
@@ -60,4 +67,10 @@ One thing worth knowing: if an earlier version already saved the wrong folder, t
 
 Run **Generate Enhancements** once after installing, then **Apply Enhancements** as usual. Several of the tracker fixes change how names and tags are built, and regenerating is what picks them up.
 
-If your Blueprint Tracker has been showing items you don't own, or missing ones you do, this is the release that should sort it. If it still looks wrong afterwards, say so on Discord, that is how every fix in this list got found.
+If your Blueprint Tracker has been showing items you don't own, or missing ones you do, this is the release that should sort it.
+
+## Questions or problems?
+
+Come find us on the **[Osiris DevWorks Discord](https://discord.gg/BNzRegKZ7k)** — join the server, then head to the [Smart Citizen feedback channel](https://discord.com/channels/1438175448420057323/1472394204347895890).
+
+If you are reporting a bug, attach your log (**Log** tab → **Export**) and mention which Star Citizen version you are on. Every single fix in this release started as someone doing exactly that.

--- a/docs/2.3.1-RELEASE-NOTES.md
+++ b/docs/2.3.1-RELEASE-NOTES.md
@@ -13,10 +13,14 @@
 
 ## Download
 
-- **[SmartCitizen-2.3.1-Setup.exe](https://github.com/Osiris-DevWorks/smart-citizen/releases/download/v2.3.1/SmartCitizen-2.3.1-Setup.exe)** — the installer, and what most people want. Auto-detects your Star Citizen install and sets up the auto-updater.
-- **[SmartCitizen-Portable-v2.3.1.zip](https://github.com/Osiris-DevWorks/smart-citizen/releases/download/v2.3.1/SmartCitizen-Portable-v2.3.1.zip)** — no install, no registry. Unzip and run the `.exe`; it keeps its settings in a `data` folder beside itself. This is also the build to use [on Linux through Wine](https://github.com/Osiris-DevWorks/smart-citizen/blob/main/docs/LINUX.md).
+**[Get the latest release](https://github.com/Osiris-DevWorks/smart-citizen/releases/latest)** — that link always points at the newest version, so if you have landed here from an older set of release notes you will still end up with the current build.
 
-Already running Smart Citizen? It checks for updates at launch and will offer to install this one for you.
+Two downloads are attached to every release:
+
+- `SmartCitizen-{VERSION}-Setup.exe` — the installer, and what most people want. Auto-detects your Star Citizen install and sets up the auto-updater.
+- `SmartCitizen-Portable-v{VERSION}.zip` — no install, no registry. Unzip and run the `.exe`; it keeps its settings in a `data` folder beside itself. This is also the build to use [on Linux through Wine](https://github.com/Osiris-DevWorks/smart-citizen/blob/main/docs/LINUX.md).
+
+Already running Smart Citizen? It checks for updates at launch and will offer to install the new version for you.
 
 ## Headline
 


### PR DESCRIPTION
Last item from `/pre_release`'s "before you ship" list. `.github/workflows/release.yml` looks for `docs/{X.Y.Z}-RELEASE-NOTES.md` first when publishing, and it didn't exist.

## Format

Matched to `docs/2.3.0-RELEASE-NOTES.md` and the six before it: Smart App Control install note (version bumped to 2.3.1), `## Headline`, themed sections, `## After you update`. User-facing register — what changed for the reader, not how it was implemented, and no issue or PR numbers in the body.

## Coverage

All nine user-visible fixes in this release are represented, verified by pattern check:

| Section | Covers |
|---|---|
| The window resizes properly now | #364 |
| Blueprint Tracker | #352, #353, #372, #374, #354, #362 |
| When Smart Citizen reads the wrong game folder | #370 |
| Fixes and polish | #363, plus three smaller items from #365 |

Deliberately absent: the CI fork guard (#378) and the Test Plan rewrite (#377/#379) — neither is user-visible.

## Two judgment calls

**#370 gets its own section rather than a bullet.** One user's report, but the failure was a 30-minute hang ending in a bare traceback — what anyone else hitting it will search for. It also states plainly that the fix prevents recurrence but **does not repair an already-saved wrong path**; without that, an affected user upgrades and finds nothing changed.

**The Blueprint Tracker section keeps the four reports as four distinct failure modes**, since they're different problems that all present as "the tracker is empty or wrong."

Docs-only change. No code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)