### PR TITLE
Move Blueprint Tracker's keyword search beneath its dropdown filters

### DIFF
--- a/src/gui/blueprint_tracker_tab.py
+++ b/src/gui/blueprint_tracker_tab.py
@@ -37,6 +37,19 @@ class _NoWheelComboBox(_NoScrollComboBox):
     inherits _NoScrollComboBox's popup-placement fix.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # #388 follow-up: Mission enumerates one entry per unique mission
+        # title in the loaded strings -- easily 100+. Uncapped, Qt's popup
+        # grows to fit every row instead of scrolling, overflowing the
+        # screen. Capping it also keeps "Any" (always index 0, and the
+        # current item until something else is picked) pinned to the top of
+        # the popup instead of Qt trying to center an oversized list around
+        # it. Type/Class/Size/Grade have far fewer values so this is a
+        # no-op for them in practice, but it's set on the shared class for
+        # consistency in case any of those lists grow later.
+        self.setMaxVisibleItems(12)
+
     def wheelEvent(self, event):  # noqa: N802 (Qt override)
         event.ignore()
 
@@ -298,6 +311,18 @@ class BlueprintTrackerTab(QWidget):
             facet_row.addWidget(lbl)
             facet_row.addWidget(combo, 1)
         layout.addLayout(facet_row)
+        self._align_mission_and_type_label_widths()
+
+        # #388 follow-up: the note explaining Type/Class/Size/Grade sits
+        # directly under the facet row it describes, still above the
+        # keyword search box below -- explanatory text about the dropdown
+        # filters reads better right next to them than after the unrelated
+        # search box.
+        self._blueprints_filter_note = QLabel(tr("enhancements.blueprints_filter_note"))
+        self._blueprints_filter_note.setProperty("role", "secondary")
+        self._blueprints_filter_note.setStyleSheet("font-size: 10px;")
+        self._blueprints_filter_note.setWordWrap(True)
+        layout.addWidget(self._blueprints_filter_note)
 
         # #388: keyword search sits beneath the dropdown/checkbox filters
         # above (mission + facet combos, show-tags toggle), matching the
@@ -311,12 +336,6 @@ class BlueprintTrackerTab(QWidget):
         self._blueprints_search.setClearButtonEnabled(True)
         self._blueprints_search.textChanged.connect(self._refilter_blueprint_lists)
         layout.addWidget(self._blueprints_search)
-
-        self._blueprints_filter_note = QLabel(tr("enhancements.blueprints_filter_note"))
-        self._blueprints_filter_note.setProperty("role", "secondary")
-        self._blueprints_filter_note.setStyleSheet("font-size: 10px;")
-        self._blueprints_filter_note.setWordWrap(True)
-        layout.addWidget(self._blueprints_filter_note)
 
         lists_row = QHBoxLayout()
 
@@ -379,6 +398,22 @@ class BlueprintTrackerTab(QWidget):
         outer.setContentsMargins(0, 0, 0, 0)
         outer.addWidget(scroll)
 
+    def _align_mission_and_type_label_widths(self) -> None:
+        """#388 follow-up: "Mission:" and "Type:" render at different
+        natural widths, so their combos started at different x positions
+        even though the two rows are meant to read as one column of
+        filters. Pad the shorter label out to match the wider one's
+        sizeHint so both combos line up -- computed from actual rendered
+        text (not a hard-coded pixel value) so it stays correct across
+        every language's translation, and re-run from retranslate_ui after
+        a language switch changes both labels' text.
+        """
+        mission_label = self._blueprints_mission_label
+        type_label = self._blueprints_facet_labels["enhancements.blueprints_facet_type"]
+        width = max(mission_label.sizeHint().width(), type_label.sizeHint().width())
+        mission_label.setMinimumWidth(width)
+        type_label.setMinimumWidth(width)
+
     def retranslate_ui(self) -> None:
         """Re-apply tr() to every text-bearing widget after a language switch."""
         self._title_label.setText(tr("blueprint_tracker.title"))
@@ -414,6 +449,7 @@ class BlueprintTrackerTab(QWidget):
         self._blueprints_remove_btn.setToolTip(tr("enhancements.blueprints_remove_tooltip"))
         for label_key, lbl in self._blueprints_facet_labels.items():
             lbl.setText(tr(label_key))
+        self._align_mission_and_type_label_widths()
 
     @staticmethod
     def _available_blueprints(all_names, owned) -> list:

--- a/src/gui/blueprint_tracker_tab.py
+++ b/src/gui/blueprint_tracker_tab.py
@@ -254,14 +254,6 @@ class BlueprintTrackerTab(QWidget):
         self._blueprints_empty_note.setWordWrap(True)
         layout.addWidget(self._blueprints_empty_note)
 
-        self._blueprints_search = QLineEdit()
-        self._blueprints_search.setPlaceholderText(
-            tr("enhancements.blueprints_search_placeholder")
-        )
-        self._blueprints_search.setClearButtonEnabled(True)
-        self._blueprints_search.textChanged.connect(self._refilter_blueprint_lists)
-        layout.addWidget(self._blueprints_search)
-
         # Display-only toggle (#221): show each item's Tag Builder tag inline
         # instead of the bare name. Matching/filtering/Owned tracking always
         # use the bare name regardless — see BlueprintItem.tagged_name.
@@ -306,6 +298,19 @@ class BlueprintTrackerTab(QWidget):
             facet_row.addWidget(lbl)
             facet_row.addWidget(combo, 1)
         layout.addLayout(facet_row)
+
+        # #388: keyword search sits beneath the dropdown/checkbox filters
+        # above (mission + facet combos, show-tags toggle), matching the
+        # String Editor's own filter row (create_string_filter_row's
+        # category/status/checkbox controls, all above the table's
+        # per-column keyword search boxes) -- was above them here instead.
+        self._blueprints_search = QLineEdit()
+        self._blueprints_search.setPlaceholderText(
+            tr("enhancements.blueprints_search_placeholder")
+        )
+        self._blueprints_search.setClearButtonEnabled(True)
+        self._blueprints_search.textChanged.connect(self._refilter_blueprint_lists)
+        layout.addWidget(self._blueprints_search)
 
         self._blueprints_filter_note = QLabel(tr("enhancements.blueprints_filter_note"))
         self._blueprints_filter_note.setProperty("role", "secondary")

--- a/src/gui/blueprint_tracker_tab.py
+++ b/src/gui/blueprint_tracker_tab.py
@@ -19,7 +19,9 @@ from PyQt6.QtWidgets import (
     QMessageBox, QPushButton, QScrollArea, QSizePolicy, QVBoxLayout, QWidget,
 )
 
-from src.gui.enhancements_tab import _NoScrollComboBox
+from src.gui.enhancements_tab import (
+    _NoScrollComboBox, reposition_combo_popup_below_if_it_fits,
+)
 from src.gui.theme import get_button_color
 from src.utils.i18n import tr
 from src.utils.settings import AppSettings
@@ -75,18 +77,12 @@ class _NoWheelComboBox(_NoScrollComboBox):
         if popup.height() <= capped_height:
             return
         popup.setFixedHeight(int(capped_height))
-        # _NoScrollComboBox's own "does it fit below" check above ran
-        # against the OLD, uncapped height -- a 100+ row list rarely fits
-        # below, so it likely left the popup flipped above the combo
-        # instead. Re-check now that the popup is a fraction of that size.
-        below_point = self.mapToGlobal(self.rect().bottomLeft())
-        screen = self.screen()
-        fits_below = (
-            screen is None
-            or below_point.y() + popup.height() <= screen.availableGeometry().bottom()
-        )
-        if fits_below:
-            popup.move(below_point)
+        # _NoScrollComboBox's own "does it fit below" check (inside the
+        # super().showPopup() call above) ran against the OLD, uncapped
+        # height -- a 100+ row list rarely fits below, so it likely left
+        # the popup flipped above the combo instead. Re-run the same check
+        # now that the popup is a fraction of that size.
+        reposition_combo_popup_below_if_it_fits(self, popup)
 
 
 def _relabel_details_button(box: QMessageBox, shown_label: str, hidden_label: str) -> None:

--- a/src/gui/blueprint_tracker_tab.py
+++ b/src/gui/blueprint_tracker_tab.py
@@ -37,21 +37,50 @@ class _NoWheelComboBox(_NoScrollComboBox):
     inherits _NoScrollComboBox's popup-placement fix.
     """
 
+    _MAX_VISIBLE_ITEMS = 12
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # #388 follow-up: Mission enumerates one entry per unique mission
-        # title in the loaded strings -- easily 100+. Uncapped, Qt's popup
-        # grows to fit every row instead of scrolling, overflowing the
-        # screen. Capping it also keeps "Any" (always index 0, and the
-        # current item until something else is picked) pinned to the top of
-        # the popup instead of Qt trying to center an oversized list around
-        # it. Type/Class/Size/Grade have far fewer values so this is a
-        # no-op for them in practice, but it's set on the shared class for
-        # consistency in case any of those lists grow later.
-        self.setMaxVisibleItems(12)
+        # Mission enumerates one entry per unique mission title in the
+        # loaded strings -- easily 100+. setMaxVisibleItems is the
+        # documented Qt knob for this, but confirmed live (#388 follow-up)
+        # it has no effect here on its own -- the popup still rendered
+        # every row uncapped. Kept anyway (harmless, correct intent, some
+        # Qt code paths still consult it for sizeHint); showPopup below
+        # does the actual capping by force.
+        self.setMaxVisibleItems(self._MAX_VISIBLE_ITEMS)
 
     def wheelEvent(self, event):  # noqa: N802 (Qt override)
         event.ignore()
+
+    def showPopup(self):  # noqa: N802 (Qt override)
+        # #388 follow-up: force the popup window's pixel height down to
+        # _MAX_VISIBLE_ITEMS rows, computed from the view's own row height
+        # so it holds regardless of font/theme. QAbstractItemView adds its
+        # own scrollbar automatically once content overflows the viewport,
+        # so capping the height is the only piece needed.
+        super().showPopup()  # _NoScrollComboBox: shows, positions below if it fits
+        view = self.view()
+        popup = view.window()
+        row_height = view.sizeHintForRow(0) if self.count() else 0
+        if row_height <= 0:
+            row_height = view.fontMetrics().height() + 6
+        capped_height = row_height * self._MAX_VISIBLE_ITEMS + 2 * view.frameWidth() + 4
+        if popup.height() <= capped_height:
+            return
+        popup.setFixedHeight(int(capped_height))
+        # _NoScrollComboBox's own "does it fit below" check above ran
+        # against the OLD, uncapped height -- a 100+ row list rarely fits
+        # below, so it likely left the popup flipped above the combo
+        # instead. Re-check now that the popup is a fraction of that size.
+        below_point = self.mapToGlobal(self.rect().bottomLeft())
+        screen = self.screen()
+        fits_below = (
+            screen is None
+            or below_point.y() + popup.height() <= screen.availableGeometry().bottom()
+        )
+        if fits_below:
+            popup.move(below_point)
 
 
 def _relabel_details_button(box: QMessageBox, shown_label: str, hidden_label: str) -> None:

--- a/src/gui/blueprint_tracker_tab.py
+++ b/src/gui/blueprint_tracker_tab.py
@@ -56,12 +56,18 @@ class _NoWheelComboBox(_NoScrollComboBox):
     def showPopup(self):  # noqa: N802 (Qt override)
         # #388 follow-up: force the popup window's pixel height down to
         # _MAX_VISIBLE_ITEMS rows, computed from the view's own row height
-        # so it holds regardless of font/theme. QAbstractItemView adds its
-        # own scrollbar automatically once content overflows the viewport,
-        # so capping the height is the only piece needed.
+        # so it holds regardless of font/theme, and force a real scrollbar
+        # (see the policy line below -- Fusion's combo popup defaults to
+        # tiny scroll-arrow buttons instead, confirmed live).
         super().showPopup()  # _NoScrollComboBox: shows, positions below if it fits
         view = self.view()
         popup = view.window()
+        # Fusion's combo popup prefers small top/bottom scroll-arrow
+        # buttons over a real scrollbar once content overflows the
+        # popup -- confirmed live (#388 follow-up), capping the height
+        # above left no visible scrollbar at all. Forcing the policy on
+        # makes Qt render the view's actual scrollbar instead.
+        view.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
         row_height = view.sizeHintForRow(0) if self.count() else 0
         if row_height <= 0:
             row_height = view.fontMetrics().height() + 6

--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -29,6 +29,32 @@ _ALL_SIZE_WORDS: frozenset[str] = frozenset(SIZE_ABBREV_BY_WORD)
 logger = logging.getLogger(__name__)
 
 
+def reposition_combo_popup_below_if_it_fits(combo, popup) -> None:
+    """Move *popup* to align with *combo*'s bottom-left corner, but only if
+    it actually fits on-screen there.
+
+    Qt's default popup placement flips the list above the box when it judges
+    there isn't room below (common in a scroll area, even when there visually
+    is room) — force it below whenever that actually fits, so the option list
+    is where the user expects it. A combo near the bottom of the screen is
+    the case Qt's flip logic exists for; forcing "below" there would run the
+    popup off the bottom of the display, so only override when there's room.
+
+    Shared by _NoScrollComboBox.showPopup below (initial placement) and
+    blueprint_tracker_tab.py's _NoWheelComboBox.showPopup (#388, re-checked
+    a second time there after forcibly shrinking an overlong popup — the
+    first check ran against the original, taller height).
+    """
+    below_point = combo.mapToGlobal(combo.rect().bottomLeft())
+    screen = combo.screen()
+    fits_below = (
+        screen is None
+        or below_point.y() + popup.height() <= screen.availableGeometry().bottom()
+    )
+    if fits_below:
+        popup.move(below_point)
+
+
 class _NoScrollComboBox(QComboBox):
     """A combo box that ignores the mouse wheel unless it has focus (#197).
 
@@ -49,23 +75,8 @@ class _NoScrollComboBox(QComboBox):
             event.ignore()
 
     def showPopup(self):  # noqa: N802 (Qt override)
-        # Qt's default popup placement flips the list above the box when it
-        # judges there isn't room below (common in this tab's scroll area,
-        # even when there visually is room) — force it below whenever that
-        # actually fits on-screen, so the option list is where the user
-        # expects it. A combo near the bottom of the screen is the case Qt's
-        # flip logic exists for; forcing "below" there would run the popup
-        # off the bottom of the display, so only override when there's room.
         super().showPopup()
-        popup = self.view().window()
-        below_point = self.mapToGlobal(self.rect().bottomLeft())
-        screen = self.screen()
-        fits_below = (
-            screen is None
-            or below_point.y() + popup.height() <= screen.availableGeometry().bottom()
-        )
-        if fits_below:
-            popup.move(below_point)
+        reposition_combo_popup_below_if_it_fits(self, self.view().window())
 
 
 class _NoScrollTabBar(QTabBar):


### PR DESCRIPTION
## Summary

Fixes #388. The Blueprint Tracker's keyword search box sat above the Mission/Type/Class/Size/Grade dropdown filters and the show-tags toggle — backwards from the String Editor's own convention, where `create_string_filter_row`'s category/status/checkbox controls all sit above the table's per-column keyword search boxes.

**Layout fix**: reordered so all dropdown/checkbox filters (show-tags toggle, Mission dropdown, Type/Class/Size/Grade facet dropdowns) sit together, with the explanatory filter note directly beneath the facet row it describes, and keyword search last — matching the String Editor's pattern.

**Follow-up polish** (from live testing during this session):
- Aligned the Mission and Type labels' widths (via `sizeHint`, so it holds across every language) so their combo boxes start at the same x position instead of drifting with each label's natural text width.
- The Mission dropdown enumerates 100+ unique mission titles. Its popup was uncapped, growing to fill the whole screen instead of scrolling. `_NoWheelComboBox.showPopup()` now forces the popup to a fixed height (12 rows) and forces a real scrollbar (Fusion's combo popup defaults to small scroll-arrow buttons instead of a scrollbar once content overflows — `setMaxVisibleItems` alone didn't take effect here, confirmed live).
- Deduped the "does the popup fit below the combo" position-check logic, which ended up needed twice (once for the initial placement, once to re-check after forcibly shrinking the popup) — extracted to a shared `reposition_combo_popup_below_if_it_fits()` in `enhancements_tab.py`, used by both `_NoScrollComboBox` (all its existing combos) and `_NoWheelComboBox`. Pure refactor, no behavior change.

## Test plan

- [x] Full suite green (1786 passed on this branch, 1934 on the combined integration branch)
- [x] `flake8` clean on both changed files (pre-existing warnings elsewhere in `enhancements_tab.py` are outside the touched lines)
- [x] Manual, iterative live testing across four portable builds this session: layout reorder, filter-note placement + label alignment, popup height cap, popup scrollbar — all confirmed working
- [x] No test coverage added: this is pure Qt widget-layout/popup-geometry behavior with no automated-testable logic extracted (same exemption as similar UI-only fixes elsewhere in this codebase — `pytest-qt` isn't a dev dependency here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)