### PR TITLE
Honor the configured cache folder in the DataForge cache migrator

### DIFF
--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -2812,30 +2812,47 @@ class AppSettings:
 
     @staticmethod
     def migrate_dataforge_cache_to_local() -> None:
-        r"""One-shot move of the DataForge XML cache from Documents → AppData\Local.
+        r"""One-shot move of the DataForge XML cache out of the user-data tree.
 
         Pre-1.0 the DataForge cache lived inside get_cache_dir() (Documents\…),
         putting ~1.4 GB of extracted XMLs into the OneDrive sync tree. Moving it
-        to AppData\Local eliminates per-file OneDrive / Defender / Indexer hooks
-        during extraction and keeps large build-artefact files out of cloud sync.
+        out eliminates per-file OneDrive / Defender / Indexer hooks during
+        extraction and keeps large build-artefact files out of cloud sync.
 
-        Idempotent: no-ops when the old path is already absent. If the new
-        location already has a valid stamp the old directory is cleaned up and
-        the migration is considered complete.
+        The destination is resolved through :meth:`get_dataforge_cache_dir`, so
+        a ``CACHE_DIR`` override set from the Config tab is honoured. Targeting
+        ``AppData\Local`` unconditionally used to drag the cache back out of a
+        user-chosen folder on the next launch, silently undoing that setting.
+
+        Idempotent: no-ops when the old path is absent or already the resolved
+        destination. If the destination already has a valid stamp the old
+        directory is cleaned up and the migration is considered complete.
         """
         import shutil
 
         old_dir = AppSettings.get_cache_dir() / "dataforge"
-        local_appdata = Path(
-            os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData" / "Local"))
-        )
-        new_dir = (
-            local_appdata / "Smart Citizen"
-            / AppSettings.get_active_channel()
-            / "cache" / "dataforge"
-        )
-
         if not old_dir.exists():
+            return
+
+        # Resolved after the early return: the getter creates the directory it
+        # returns, and a launch with nothing to migrate shouldn't leave an empty
+        # cache tree behind as a side effect. It can also raise when an override
+        # points at absent removable/network storage — that must not abort
+        # startup, since this runs before any window exists.
+        try:
+            new_dir = AppSettings.get_dataforge_cache_dir()
+        except OSError as e:
+            logger.warning(
+                f"DataForge cache destination unavailable ({e}); skipping migration"
+            )
+            return
+
+        try:
+            if old_dir.resolve() == new_dir.resolve():
+                return
+        except OSError:
+            # Can't prove the two differ; skipping costs one deferred migration,
+            # while continuing could rmtree what turns out to be the only copy.
             return
 
         from src.utils.pak_extractor import P4K_MTIME_STAMP
@@ -2849,16 +2866,46 @@ class AppSettings:
                 logger.warning(f"Could not remove old DataForge cache at {old_dir}: {e}")
             return
 
+        # get_dataforge_cache_dir() creates the destination; shutil.move would
+        # then nest the source inside it. Drop the empty placeholder so the move
+        # is a plain rename, and bail out if it holds unstamped data.
+        if new_dir.exists():
+            try:
+                new_dir.rmdir()
+            except OSError as e:
+                logger.warning(
+                    f"DataForge cache destination {new_dir} is unusable ({e}); "
+                    f"leaving old copy at {old_dir}"
+                )
+                return
+
+        # Once CACHE_DIR points at another drive the move is cross-volume, which
+        # shutil implements as a non-atomic copytree + rmtree. Stage it under a
+        # name the freshness check never accepts so an interrupted copy cannot
+        # leave a stamped-but-partial cache at new_dir — the next launch would
+        # trust that stamp and delete the intact source for it.
+        staging = new_dir.parent / f"{new_dir.name}.migrating"
         logger.info(f"Migrating DataForge cache: {old_dir} → {new_dir}")
         try:
             new_dir.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(old_dir), str(new_dir))
+            if staging.exists():
+                shutil.rmtree(staging, ignore_errors=True)
+            shutil.move(str(old_dir), str(staging))
+            staging.rename(new_dir)
             logger.info("DataForge cache migration complete")
         except Exception as e:
             logger.warning(
                 f"DataForge cache migration failed ({e}); "
                 "cache will be re-extracted on next use"
             )
+            # Only discard the staged copy while the source is still intact;
+            # past that point staging may hold the only copy of the cache.
+            if old_dir.exists():
+                shutil.rmtree(staging, ignore_errors=True)
+            elif staging.exists():
+                logger.warning(
+                    f"Partially migrated DataForge cache left at {staging}"
+                )
 
     @staticmethod
     def migrate_data_to_documents() -> None:

--- a/tests/test_cache_dir.py
+++ b/tests/test_cache_dir.py
@@ -193,3 +193,231 @@ class TestPendingCleanup:
         AppSettings.set_pending_cache_cleanup(tmp_path / "old-cache")
         AppSettings.set_pending_cache_cleanup("")
         assert AppSettings.get_pending_cache_cleanup() == ""
+
+
+def _seed_cache(path: Path, stamp_value: str = "123") -> Path:
+    """Create a DataForge-cache-shaped dir with a valid freshness stamp."""
+    from src.utils.pak_extractor import P4K_MTIME_STAMP
+
+    path.mkdir(parents=True, exist_ok=True)
+    (path / P4K_MTIME_STAMP).write_text(stamp_value)
+    (path / "raw").mkdir(exist_ok=True)
+    (path / "raw" / "record.xml").write_text("<x/>")
+    return path
+
+
+def _has_stamp(path: Path) -> bool:
+    from src.utils.pak_extractor import P4K_MTIME_STAMP
+
+    return (path / P4K_MTIME_STAMP).exists()
+
+
+class TestMigrateRespectsConfiguredCacheDir:
+    """``migrate_dataforge_cache_to_local`` must target the *resolved*
+    cache dir, not a hardcoded %LOCALAPPDATA%.
+
+    Regression: the migrator computed its destination as
+    ``%LOCALAPPDATA%\\Smart Citizen\\{channel}\\cache\\dataforge`` directly
+    while ``get_dataforge_cache_dir()`` honoured CACHE_DIR. A user who
+    pointed the Config tab's DataForge Cache Folder at another drive got
+    the cache silently dragged back to LOCALAPPDATA on the next launch,
+    undoing the setting every single time.
+    """
+
+    def test_override_equal_to_user_data_dir_is_left_alone(
+        self, json_backend, registry_mode, monkeypatch, tmp_path
+    ):
+        """The exact reported case: CACHE_DIR == USER_DATA_DIR makes the
+        migrator's source and destination the same path. It must no-op
+        instead of moving the cache out to LOCALAPPDATA."""
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "LocalAppData"))
+        root = tmp_path / "data" / "Smart Citizen"
+        AppSettings.set_user_data_dir(root)
+        AppSettings.set_cache_dir(root)
+
+        cache = _seed_cache(root / "LIVE" / "cache" / "dataforge")
+
+        AppSettings.migrate_dataforge_cache_to_local()
+
+        assert _has_stamp(cache), "configured cache must stay put"
+        stray = tmp_path / "LocalAppData" / "Smart Citizen" / "LIVE" / "cache" / "dataforge"
+        assert not _has_stamp(stray), "must not be dragged back to LOCALAPPDATA"
+
+    def test_override_moves_cache_to_override_not_localappdata(
+        self, json_backend, registry_mode, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "LocalAppData"))
+        AppSettings.set_user_data_dir(tmp_path / "userdata")
+        AppSettings.set_cache_dir(tmp_path / "fast-ssd")
+
+        old = _seed_cache(tmp_path / "userdata" / "LIVE" / "cache" / "dataforge", "456")
+
+        AppSettings.migrate_dataforge_cache_to_local()
+
+        dest = (tmp_path / "fast-ssd").resolve() / "LIVE" / "cache" / "dataforge"
+        assert _has_stamp(dest)
+        assert not old.exists()
+        assert not (dest / "dataforge").exists(), "must rename, not nest inside dest"
+
+    def test_no_override_still_moves_to_localappdata(
+        self, json_backend, registry_mode, monkeypatch, tmp_path
+    ):
+        """Back-compat: an unchanged install (no CACHE_DIR) keeps the
+        historic Documents -> LOCALAPPDATA behaviour."""
+        fake_local = tmp_path / "LocalAppData"
+        monkeypatch.setenv("LOCALAPPDATA", str(fake_local))
+        AppSettings.set_user_data_dir(tmp_path / "Documents" / "Smart Citizen")
+
+        old = _seed_cache(
+            tmp_path / "Documents" / "Smart Citizen" / "LIVE" / "cache" / "dataforge", "789"
+        )
+
+        AppSettings.migrate_dataforge_cache_to_local()
+
+        dest = fake_local / "Smart Citizen" / "LIVE" / "cache" / "dataforge"
+        assert _has_stamp(dest)
+        assert not old.exists()
+
+    def test_stamped_destination_removes_stale_source(
+        self, json_backend, registry_mode, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "LocalAppData"))
+        AppSettings.set_user_data_dir(tmp_path / "userdata")
+        AppSettings.set_cache_dir(tmp_path / "fast-ssd")
+
+        old = _seed_cache(tmp_path / "userdata" / "LIVE" / "cache" / "dataforge", "old")
+        dest = _seed_cache(
+            (tmp_path / "fast-ssd").resolve() / "LIVE" / "cache" / "dataforge", "new"
+        )
+
+        AppSettings.migrate_dataforge_cache_to_local()
+
+        assert not old.exists(), "stale source should be cleaned up"
+        from src.utils.pak_extractor import P4K_MTIME_STAMP
+        assert (dest / P4K_MTIME_STAMP).read_text() == "new"
+
+    def test_is_idempotent(self, json_backend, registry_mode, monkeypatch, tmp_path):
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "LocalAppData"))
+        AppSettings.set_user_data_dir(tmp_path / "userdata")
+        AppSettings.set_cache_dir(tmp_path / "fast-ssd")
+        _seed_cache(tmp_path / "userdata" / "LIVE" / "cache" / "dataforge", "abc")
+
+        AppSettings.migrate_dataforge_cache_to_local()
+        AppSettings.migrate_dataforge_cache_to_local()
+
+        dest = (tmp_path / "fast-ssd").resolve() / "LIVE" / "cache" / "dataforge"
+        assert _has_stamp(dest)
+        assert not (dest / "dataforge").exists()
+
+
+class TestMigrateDoesNotDestroyCache:
+    """Destructive-path guards for ``migrate_dataforge_cache_to_local``.
+
+    The function moves and then deletes a ~1.2 GB user cache, so every
+    branch that can reach an ``rmtree`` needs a test. Once CACHE_DIR points
+    at a second drive the move is cross-volume, which shutil implements as
+    a non-atomic copytree + rmtree — an interrupted copy must never be able
+    to masquerade as a complete cache on the following launch.
+    """
+
+    def test_unstamped_nonempty_destination_is_left_alone(
+        self, json_backend, registry_mode, monkeypatch, tmp_path
+    ):
+        """A partial extraction already sitting at the destination must not
+        cost the user their good source cache."""
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "LocalAppData"))
+        AppSettings.set_user_data_dir(tmp_path / "userdata")
+        AppSettings.set_cache_dir(tmp_path / "fast-ssd")
+
+        old = _seed_cache(tmp_path / "userdata" / "LIVE" / "cache" / "dataforge", "good")
+        dest = (tmp_path / "fast-ssd").resolve() / "LIVE" / "cache" / "dataforge"
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "partial.xml").write_text("<x/>")
+
+        AppSettings.migrate_dataforge_cache_to_local()
+
+        assert _has_stamp(old), "source must survive an unusable destination"
+        assert (dest / "partial.xml").exists(), "destination must be untouched"
+
+    def test_interrupted_move_never_strands_a_stamped_partial(
+        self, json_backend, registry_mode, monkeypatch, tmp_path
+    ):
+        """Simulates a cross-volume copy dying after the stamp made it across
+        (stamps sort ahead of ``raw/`` in scandir order). The destination must
+        not end up looking like a valid cache."""
+        import shutil
+
+        from src.utils.pak_extractor import P4K_MTIME_STAMP
+
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "LocalAppData"))
+        AppSettings.set_user_data_dir(tmp_path / "userdata")
+        AppSettings.set_cache_dir(tmp_path / "fast-ssd")
+
+        old = _seed_cache(tmp_path / "userdata" / "LIVE" / "cache" / "dataforge", "good")
+        dest = (tmp_path / "fast-ssd").resolve() / "LIVE" / "cache" / "dataforge"
+
+        def exploding_move(src, dst):
+            Path(dst).mkdir(parents=True, exist_ok=True)
+            (Path(dst) / P4K_MTIME_STAMP).write_text("partial")
+            raise OSError("No space left on device")
+
+        monkeypatch.setattr(shutil, "move", exploding_move)
+        AppSettings.migrate_dataforge_cache_to_local()
+
+        assert _has_stamp(old), "source must survive a failed move"
+        assert not _has_stamp(dest), "no stamped partial may be left at the destination"
+
+    def test_source_survives_relaunch_after_interrupted_move(
+        self, json_backend, registry_mode, monkeypatch, tmp_path
+    ):
+        """The regression that makes the previous case dangerous: on the next
+        launch a stamped partial would send the stamp branch straight into
+        rmtree(old_dir), destroying the only complete copy."""
+        import shutil
+
+        from src.utils.pak_extractor import P4K_MTIME_STAMP
+
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "LocalAppData"))
+        AppSettings.set_user_data_dir(tmp_path / "userdata")
+        AppSettings.set_cache_dir(tmp_path / "fast-ssd")
+
+        old = _seed_cache(tmp_path / "userdata" / "LIVE" / "cache" / "dataforge", "good")
+
+        def exploding_move(src, dst):
+            Path(dst).mkdir(parents=True, exist_ok=True)
+            (Path(dst) / P4K_MTIME_STAMP).write_text("partial")
+            raise OSError("No space left on device")
+
+        monkeypatch.setattr(shutil, "move", exploding_move)
+        AppSettings.migrate_dataforge_cache_to_local()
+
+        monkeypatch.undo()
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "LocalAppData"))
+        AppSettings.migrate_dataforge_cache_to_local()
+
+        dest = (tmp_path / "fast-ssd").resolve() / "LIVE" / "cache" / "dataforge"
+        assert _has_stamp(dest), "retry should complete the migration"
+        assert (dest / P4K_MTIME_STAMP).read_text() == "good"
+        assert not old.exists()
+
+    def test_unavailable_destination_does_not_raise(
+        self, json_backend, registry_mode, monkeypatch, tmp_path
+    ):
+        """An override pointing at absent removable/network storage must not
+        abort startup — the migrator runs before any window exists."""
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "LocalAppData"))
+        AppSettings.set_user_data_dir(tmp_path / "userdata")
+        AppSettings.set_cache_dir(tmp_path / "gone")
+
+        old = _seed_cache(tmp_path / "userdata" / "LIVE" / "cache" / "dataforge", "good")
+
+        def boom():
+            raise OSError(3, "The system cannot find the path specified")
+
+        monkeypatch.setattr(
+            AppSettings, "get_dataforge_cache_dir", staticmethod(boom)
+        )
+
+        AppSettings.migrate_dataforge_cache_to_local()
+
+        assert _has_stamp(old), "source must be untouched when the target is gone"


### PR DESCRIPTION
migrate_dataforge_cache_to_local() computed its destination as a hardcoded %LOCALAPPDATA%\Smart Citizen\{channel}\cache\dataforge, while get_dataforge_cache_dir() honors the CACHE_DIR override. A user who pointed the Config tab's DataForge Cache Folder at another drive had the ~1.2 GB cache dragged back to LocalAppData on the next launch, silently undoing the setting on every start.

Resolve the destination through get_dataforge_cache_dir() so the override is respected, return early when source and destination are the same path, and drop the empty destination directory that getter creates so the move renames instead of nesting a dataforge/dataforge.

Honoring the override makes a cross-volume move the normal case, and shutil implements that as a non-atomic copytree + rmtree. Stage the copy as dataforge.migrating and rename it into place, so an interrupted copy cannot leave a stamped-but-partial cache that the next launch would trust (dataforge_cache_is_fresh only checks the stamp, raw/libs and one XML) before deleting the intact source for it. Guard the destination lookup too: it mkdirs, so an override pointing at absent removable or network storage would otherwise raise out of startup before any window exists.

The CACHE_DIR -> portable -> LOCALAPPDATA resolution order is unchanged; this only makes the migrator consistent with it. Adds the first regression coverage for this migrator, including the back-compat path where an install with no override still migrates to LocalAppData and the destructive paths that can reach an rmtree.